### PR TITLE
Annotate child API modules with JvmField

### DIFF
--- a/lib/src/main/kotlin/com/workos/WorkOS.kt
+++ b/lib/src/main/kotlin/com/workos/WorkOS.kt
@@ -51,17 +51,14 @@ class WorkOS(
 
   private val mapper = jacksonObjectMapper()
 
-  val directorySync by lazy {
-    DirectorySyncApi(this)
-  }
+  @JvmField
+  val directorySync = DirectorySyncApi(this)
 
-  val organizations by lazy {
-    OrganizationsApi(this)
-  }
+  @JvmField
+  val organizations = OrganizationsApi(this)
 
-  val sso by lazy {
-    SsoApi(this)
-  }
+  @JvmField
+  val sso = SsoApi(this)
 
   init {
     mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)


### PR DESCRIPTION
Unfortunately we can use the lazy delegated values _and_ make these fields available in Java :(