### PR TITLE
Enable Nexus staging deployment

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,3 @@
 rootProject.name = "workos-kotlin"
+rootProject.projectDir = File("workos")
 include("workos")

--- a/workos/build.gradle.kts
+++ b/workos/build.gradle.kts
@@ -1,12 +1,18 @@
 group = "com.workos"
 version = "1.0.0-beta-0"
 
+if (!project.hasProperty("release")) {
+  version = "$version-SNAPSHOT"
+}
+
 plugins {
   id("org.jetbrains.kotlin.jvm") version "1.5.0"
 
   id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
 
   id("org.jetbrains.dokka") version "1.5.30"
+
+  id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 
   signing
 
@@ -73,9 +79,6 @@ publishing {
   publications {
     create<MavenPublication>("maven") {
       artifactId = "workos"
-      if (!project.hasProperty("release")) {
-        version = "$version-SNAPSHOT"
-      }
 
       from(components["java"])
 
@@ -104,21 +107,13 @@ publishing {
       }
     }
   }
+}
 
+nexusPublishing {
   repositories {
-    maven {
-      val ossrhUsername: String? by project
-      val ossrhPassword: String? by project
-
-      val releasesRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/releases")
-      val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots")
-
-      url = uri(if (project.hasProperty("release")) releasesRepoUrl else snapshotsRepoUrl)
-
-      credentials {
-        username = ossrhUsername
-        password = ossrhPassword
-      }
+    create("myNexus") {
+      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
     }
   }
 }


### PR DESCRIPTION
Adds `io.github.gradle-nexus.publish-plugin` which makes the release process much easier.