### PR TITLE
Add Semaphore promotion for publishing

### DIFF
--- a/.semaphore/maven.yml
+++ b/.semaphore/maven.yml
@@ -1,0 +1,23 @@
+version: v1.0
+
+name: Publish to Maven Central
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+
+blocks:
+  - name: Publish
+    task:
+      secrets:
+        - name: workos-maven-central
+      prologue:
+        commands:
+          - checkout
+          - cp /home/semaphore/gradle/signing.key ./signing.key
+          - cp /home/semaphore/gradle/gradle.properties ./gradle.properties
+      jobs:
+        - name: publish to nexus staging repository
+          commands:
+            - ./gradlew publishToMyNexus closeAndReleaseMyNexusStagingRepository -Prelease

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,3 +26,7 @@ blocks:
       epilogue:
         commands:
           - artifact push job lib/build/reports/tests/test
+
+promotions:
+  - name: Publish to Maven Central
+    pipeline_file: maven.yml


### PR DESCRIPTION
Now we'll be able to manage the entire release process from CI via Semaphore promotions.