### PR TITLE
Add OrganizationDomain fields

### DIFF
--- a/src/main/kotlin/com/workos/organizations/models/OrganizationDomain.kt
+++ b/src/main/kotlin/com/workos/organizations/models/OrganizationDomain.kt
@@ -2,6 +2,8 @@ package com.workos.organizations.models
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.organizations.types.OrganizationDomainState
+import com.workos.organizations.types.OrganizationDomainVerificationStrategy
 
 /**
  * An Organization Domain (also known as a User Email Domain) represents an Organization's domain.
@@ -23,5 +25,17 @@ data class OrganizationDomain
   val id: String,
 
   @JvmField
-  val domain: String
+  val domain: String,
+
+  @JvmField
+  @JsonProperty("state")
+  val state: OrganizationDomainState? = null,
+
+  @JvmField
+  @JsonProperty("verification_strategy")
+  val verificationStrategy: OrganizationDomainVerificationStrategy? = null,
+
+  @JvmField
+  @JsonProperty("verification_token")
+  val verificationToken: String? = null
 )

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainState.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainState.kt
@@ -1,0 +1,25 @@
+package com.workos.organizations.types
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class OrganizationDomainState(@JsonValue val type: String) {
+  /**
+   * Failed
+   */
+  Failed("failed"),
+
+  /**
+   * Legacy Verified
+   */
+  LegacyVerified("legacy_verified"),
+
+  /**
+   * Pending
+   */
+  Pending("pending"),
+
+  /**
+   * Verified
+   */
+  Verified("verified");
+}

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainVerificationStrategy.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainVerificationStrategy.kt
@@ -1,0 +1,15 @@
+package com.workos.organizations.types
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class OrganizationDomainVerificationStrategy(@JsonValue val type: String) {
+  /**
+   * DNS
+   */
+  Dns("dns"),
+
+  /**
+   * Manual
+   */
+  Manual("manual")
+}

--- a/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
@@ -8,6 +8,8 @@ import com.workos.organizations.OrganizationsApi.CreateOrganizationRequestOption
 import com.workos.organizations.OrganizationsApi.UpdateOrganizationOptions
 import com.workos.organizations.types.OrganizationDomainDataOptions
 import com.workos.organizations.types.OrganizationDomainDataState
+import com.workos.organizations.types.OrganizationDomainState
+import com.workos.organizations.types.OrganizationDomainVerificationStrategy
 import com.workos.test.TestBase
 import org.junit.jupiter.api.Assertions.assertThrows
 import kotlin.test.Test
@@ -260,7 +262,10 @@ class OrganizationsApiTest : TestBase() {
           {
             "domain": "example.com",
             "object": "organization_domain",
-            "id": "$organizationDomainId"
+            "id": "$organizationDomainId",
+            "state": "verified",
+            "verification_strategy": "dns",
+            "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
           }
         ]
       }"""
@@ -271,6 +276,9 @@ class OrganizationsApiTest : TestBase() {
     assertEquals(organizationId, organization.id)
     assertEquals(organizationDomainName, organization.name)
     assertEquals(organizationDomainId, organization.domains[0].id)
+    assertEquals(OrganizationDomainState.Verified, organization.domains[0].state)
+    assertEquals(OrganizationDomainVerificationStrategy.Dns, organization.domains[0].verificationStrategy)
+    assertEquals("rqURsMUCuiaSggGyed8ZAnMk", organization.domains[0].verificationToken)
   }
 
   @Test
@@ -296,7 +304,10 @@ class OrganizationsApiTest : TestBase() {
               {
                 "domain": "example.com",
                 "object": "organization_domain",
-                "id": "$organizationDomainId"
+                "id": "$organizationDomainId",
+                "state": "verified",
+                "verification_strategy": "dns",
+                "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
               }
             ]
           }
@@ -313,6 +324,9 @@ class OrganizationsApiTest : TestBase() {
     assertEquals(organizationId, organizations.get(0).id)
     assertEquals(organizationDomainName, organizations.get(0).name)
     assertEquals(organizationDomainId, organizations.get(0).domains[0].id)
+    assertEquals(OrganizationDomainState.Verified, organizations.get(0).domains[0].state)
+    assertEquals(OrganizationDomainVerificationStrategy.Dns, organizations.get(0).domains[0].verificationStrategy)
+    assertEquals("rqURsMUCuiaSggGyed8ZAnMk", organizations.get(0).domains[0].verificationToken)
   }
 
   @Test
@@ -339,7 +353,10 @@ class OrganizationsApiTest : TestBase() {
               {
                 "domain": "example.com",
                 "object": "organization_domain",
-                "id": "$organizationDomainId"
+                "id": "$organizationDomainId",
+                "state": "verified",
+                "verification_strategy": "dns",
+                "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
               }
             ]
           }
@@ -385,7 +402,10 @@ class OrganizationsApiTest : TestBase() {
               {
                 "domain": "example.com",
                 "object": "organization_domain",
-                "id": "$organizationDomainId"
+                "id": "$organizationDomainId",
+                "state": "verified",
+                "verification_strategy": "dns",
+                "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
               }
             ]
           }


### PR DESCRIPTION
## Description

Adds some additional organization-domain fields returned by the API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
