### PR TITLE
Add user webhook events

### DIFF
--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -169,5 +169,20 @@ enum class EventType(
   /**
    * Triggers when a user successfully resets their password.
    */
-  PasswordResetSucceeded("password_reset.succeeded")
+  PasswordResetSucceeded("password_reset.succeeded"),
+
+  /**
+   * Triggers when a user is created.
+   */
+  UserCreated("user.created"),
+
+  /**
+   * Triggers when a user is updated.
+   */
+  UserUpdated("user.updated"),
+
+  /**
+   * Triggers when a user is deleted.
+   */
+  UserDeleted("user.deleted")
 }

--- a/src/main/kotlin/com/workos/webhooks/models/UserCreatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/UserCreatedEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.User
+
+/**
+ * Webhook Event for `user.created`.
+ */
+class UserCreatedEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: User,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/UserDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/UserDeletedEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.User
+
+/**
+ * Webhook Event for `user.deleted`.
+ */
+class UserDeletedEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: User,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/UserUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/UserUpdatedEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.User
+
+/**
+ * Webhook Event for `user.updated`.
+ */
+class UserUpdatedEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: User,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -17,6 +17,7 @@ import com.workos.usermanagement.models.InvitationEventData
 import com.workos.usermanagement.models.MagicAuthEventData
 import com.workos.usermanagement.models.OrganizationMembership
 import com.workos.usermanagement.models.PasswordResetEventData
+import com.workos.usermanagement.models.User as UserManagementUser
 
 /**
  * Custom JSON deserializer for [com.workos.webhooks.models.WebhookEvent] events.
@@ -72,6 +73,9 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.PasswordResetCreated -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
       EventType.PasswordResetSucceeded -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
+      EventType.UserCreated -> UserCreatedEvent(id, eventType, deserializeData(data, UserManagementUser::class.java), createdAt)
+      EventType.UserUpdated -> UserUpdatedEvent(id, eventType, deserializeData(data, UserManagementUser::class.java), createdAt)
+      EventType.UserDeleted -> UserDeletedEvent(id, eventType, deserializeData(data, UserManagementUser::class.java), createdAt)
     }
   }
 

--- a/src/test/kotlin/com/workos/test/webhooks/UserWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/UserWebhookTests.kt
@@ -1,0 +1,88 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EventType
+import com.workos.webhooks.models.UserCreatedEvent
+import com.workos.webhooks.models.UserDeletedEvent
+import com.workos.webhooks.models.UserUpdatedEvent
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class UserWebhookTests : TestBase() {
+
+  private val userId = "user_01HWZBQAY251RZ9BKB4RZW4D4A"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "id": "$userId",
+        "email": "marcelina@foo-corp.com",
+        "first_name": "Marcelina",
+        "last_name": "Davis",
+        "email_verified": true,
+        "profile_picture_url": "https://example.com/profile.jpg",
+        "last_sign_in_at": "2023-11-27T18:00:00.000Z",
+        "created_at": "2023-11-27T19:07:33.155Z",
+        "updated_at": "2023-11-27T19:07:33.155Z"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructUserCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.UserCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is UserCreatedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as UserCreatedEvent).data.id, userId)
+  }
+
+  @Test
+  fun constructUserUpdatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.UserUpdated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is UserUpdatedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as UserUpdatedEvent).data.id, userId)
+  }
+
+  @Test
+  fun constructUserDeletedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.UserDeleted)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is UserDeletedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as UserDeletedEvent).data.id, userId)
+  }
+}


### PR DESCRIPTION
- `user.created`
- `user.updated`
- `user.deleted`

## Description

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
