### PR TITLE
Added missing model fields

### DIFF
--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -24,8 +24,8 @@ class OrganizationsApi(private val workos: WorkOS) {
    * @param allowProfilesOutsideOrganization Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
    * @param domainData A list of data for the domains of the organization.
    * @param domains A list of domains for the organization.
-   * @param externalId The external ID of the user.
-   * @param metadata Object containing metadata key/value pairs associated with the user.
+   * @param externalId The external ID of the organization.
+   * @param metadata Object containing metadata key/value pairs associated with the organization.
    */
   @JsonInclude(Include.NON_NULL)
   class CreateOrganizationOptions @JvmOverloads constructor(
@@ -243,8 +243,8 @@ class OrganizationsApi(private val workos: WorkOS) {
    * @param domainData A list of data for the domains of the organization.
    * @param domains A list of domains for the organization.
    * @param stripeCustomerId The Stripe customer ID associated with this organization.
-   * @param externalId The external ID of the user.
-   * @param metadata Object containing metadata key/value pairs associated with the user.
+   * @param externalId The external ID of the organization.
+   * @param metadata Object containing metadata key/value pairs associated with the organization.
    */
   @JsonInclude(Include.NON_NULL)
   class UpdateOrganizationOptions @JvmOverloads constructor(

--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -24,6 +24,8 @@ class OrganizationsApi(private val workos: WorkOS) {
    * @param allowProfilesOutsideOrganization Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
    * @param domainData A list of data for the domains of the organization.
    * @param domains A list of domains for the organization.
+   * @param externalId The external ID of the user.
+   * @param metadata Object containing metadata key/value pairs associated with the user.
    */
   @JsonInclude(Include.NON_NULL)
   class CreateOrganizationOptions @JvmOverloads constructor(
@@ -36,7 +38,13 @@ class OrganizationsApi(private val workos: WorkOS) {
     val domainData: List<OrganizationDomainDataOptions>? = null,
 
     @Deprecated("Use domainData instead.")
-    val domains: List<String>? = null
+    val domains: List<String>? = null,
+
+    @JsonProperty("external_id")
+    val externalId: String? = null,
+
+    @JsonProperty("metadata")
+    val metadata: Map<String, String>? = null,
   ) {
     /**
      * Builder class for creating [CreateOrganizationOptions].
@@ -49,6 +57,10 @@ class OrganizationsApi(private val workos: WorkOS) {
       private var domainData: List<OrganizationDomainDataOptions>? = null
 
       private var domains: List<String>? = null
+
+      private var externalId: String? = null
+
+      private var metadata: Map<String, String>? = null
 
       /**
        * Sets the name of the organization.
@@ -73,10 +85,20 @@ class OrganizationsApi(private val workos: WorkOS) {
       fun domains(value: List<String>) = apply { domains = value }
 
       /**
+       * Sets the external ID for the organization.
+       */
+      fun externalId(value: String) = apply { externalId = value }
+
+      /**
+       * Sets the metadata for the organization.
+       */
+      fun metadata(value: Map<String, String>) = apply { metadata = value }
+
+      /**
        * Creates an instance of [CreateOrganizationOptions] with the given params.
        */
       fun build(): CreateOrganizationOptions {
-        return CreateOrganizationOptions(name, allowProfilesOutsideOrganization, domainData, domains)
+        return CreateOrganizationOptions(name, allowProfilesOutsideOrganization, domainData, domains, externalId, metadata)
       }
     }
 
@@ -220,6 +242,9 @@ class OrganizationsApi(private val workos: WorkOS) {
    * @param allowProfilesOutsideOrganization Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
    * @param domainData A list of data for the domains of the organization.
    * @param domains A list of domains for the organization.
+   * @param stripeCustomerId The Stripe customer ID associated with this organization.
+   * @param externalId The external ID of the user.
+   * @param metadata Object containing metadata key/value pairs associated with the user.
    */
   @JsonInclude(Include.NON_NULL)
   class UpdateOrganizationOptions @JvmOverloads constructor(
@@ -232,7 +257,16 @@ class OrganizationsApi(private val workos: WorkOS) {
     val domainData: List<OrganizationDomainDataOptions>? = null,
 
     @Deprecated("Use domainData instead.")
-    val domains: List<String>? = null
+    val domains: List<String>? = null,
+
+    @JsonProperty("stripe_customer_id")
+    val stripeCustomerId: String? = null,
+
+    @JsonProperty("external_id")
+    val externalId: String? = null,
+
+    @JsonProperty("metadata")
+    val metadata: Map<String, String>? = null,
   ) {
     /**
      * Builder class for [UpdateOrganizationOptions].
@@ -245,6 +279,12 @@ class OrganizationsApi(private val workos: WorkOS) {
       private var domainData: List<OrganizationDomainDataOptions>? = null
 
       private var domains: List<String>? = null
+
+      private var stripeCustomerId: String? = null
+
+      private var externalId: String? = null
+
+      private var metadata: Map<String, String>? = null
 
       /**
        * Sets the name of the organization.
@@ -269,10 +309,25 @@ class OrganizationsApi(private val workos: WorkOS) {
       fun domains(value: List<String>) = apply { domains = value }
 
       /**
+       * Sets the Stripe customer ID associated with this organization.
+       */
+      fun stripeCustomerId(value: String) = apply { stripeCustomerId = value }
+
+      /**
+       * Sets the external ID for the organization.
+       */
+      fun externalId(value: String) = apply { externalId = value }
+
+      /**
+       * Sets the metadata for the organization.
+       */
+      fun metadata(value: Map<String, String>) = apply { metadata = value }
+
+      /**
        * Creates an instance of [UpdateOrganizationOptions].
        */
       fun build(): UpdateOrganizationOptions {
-        return UpdateOrganizationOptions(name, allowProfilesOutsideOrganization, domainData, domains)
+        return UpdateOrganizationOptions(name, allowProfilesOutsideOrganization, domainData, domains, stripeCustomerId, externalId, metadata)
       }
     }
 

--- a/src/main/kotlin/com/workos/organizations/models/Organization.kt
+++ b/src/main/kotlin/com/workos/organizations/models/Organization.kt
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param domains List of [OrganizationDomain]s.
  * @param createdAt The timestamp of when the Organization was created.
  * @param updatedAt The timestamp of when the Organization was updated.
+ * @param stripeCustomerId The Stripe customer ID associated with this organization.
+ * @param externalId The external ID of the Organization.
+ * @param metadata Object containing metadata key/value pairs associated with the Organization.
  */
 data class Organization
 @JsonCreator constructor(
@@ -40,5 +43,14 @@ data class Organization
 
   @JvmField
   @JsonProperty("updated_at")
-  val updatedAt: String
+  val updatedAt: String,
+
+  @JsonProperty("stripe_customer_id")
+  val stripeCustomerId: String? = null,
+
+  @JsonProperty("external_id")
+  val externalId: String? = null,
+
+  @JsonProperty("metadata")
+  val metadata: Map<String, String>? = null,
 )

--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -27,6 +27,7 @@ import com.workos.usermanagement.models.OrganizationMemberships
 import com.workos.usermanagement.models.PasswordReset
 import com.workos.usermanagement.models.RefreshAuthentication
 import com.workos.usermanagement.models.User
+import com.workos.usermanagement.models.UserResponse
 import com.workos.usermanagement.models.Users
 import com.workos.usermanagement.types.AuthenticationAdditionalOptions
 import com.workos.usermanagement.types.CreateMagicAuthOptions
@@ -355,13 +356,15 @@ class UserManagementApi(private val workos: WorkOS) {
 
   /** Sets a new password using the `token` query parameter from the link that the user received. */
   fun resetPassword(token: String, newPassword: String): User {
-    return workos.post(
+    val userResponse = workos.post(
       "/user_management/password_reset/confirm",
-      User::class.java,
+      UserResponse::class.java,
       RequestConfig.builder()
         .data(ResetPasswordOptionsBuilder.create(token, newPassword).build())
         .build()
     )
+
+    return userResponse.user
   }
 
   /** Get the details of an existing organization membership. */

--- a/src/main/kotlin/com/workos/usermanagement/builders/AbstractUserOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AbstractUserOptionsBuilder.kt
@@ -12,6 +12,8 @@ import com.workos.usermanagement.types.PasswordHashTypeEnumType
  * @param firstName The first name of the user.
  * @param lastName The last name of the user.
  * @param emailVerified Whether the user’s email address was previously verified.
+ * @param externalId The external ID of the user.
+ * @param metadata Object containing metadata key/value pairs associated with the user.
  */
 abstract class AbstractUserOptionsBuilder<OptionsObject> @JvmOverloads constructor(
   open var password: String? = null,
@@ -20,6 +22,8 @@ abstract class AbstractUserOptionsBuilder<OptionsObject> @JvmOverloads construct
   open var firstName: String? = null,
   open var lastName: String? = null,
   open var emailVerified: Boolean? = null,
+  open var externalId: String? = null,
+  open var metadata: Map<String, String>? = null,
 ) {
   /**
    * Password
@@ -54,6 +58,16 @@ abstract class AbstractUserOptionsBuilder<OptionsObject> @JvmOverloads construct
    * existing user store, this can be set to true to mark it as already verified.
    */
   fun emailVerified(value: Boolean) = apply { emailVerified = value }
+
+  /**
+   * External ID
+   */
+  fun externalId(value: String) = apply { externalId = value }
+
+  /**
+   * Metadata
+   */
+  fun metadata(value: Map<String, String>) = apply { metadata = value }
 
   /**
    * Generates the options object.

--- a/src/main/kotlin/com/workos/usermanagement/builders/CreateUserOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/CreateUserOptionsBuilder.kt
@@ -13,6 +13,8 @@ import com.workos.usermanagement.types.PasswordHashTypeEnumType
  * @param firstName The first name of the user.
  * @param lastName The last name of the user.
  * @param emailVerified Whether the user’s email address was previously verified.
+ * @param externalId The external ID of the user.
+ * @param metadata Object containing metadata key/value pairs associated with the user.
  */
 class CreateUserOptionsBuilder @JvmOverloads constructor(
   val email: String,
@@ -22,13 +24,17 @@ class CreateUserOptionsBuilder @JvmOverloads constructor(
   override var firstName: String? = null,
   override var lastName: String? = null,
   override var emailVerified: Boolean? = null,
+  override var externalId: String? = null,
+  override var metadata: Map<String, String>? = null,
 ) : AbstractUserOptionsBuilder<CreateUserOptions>(
   password,
   passwordHash,
   passwordHashType,
   firstName,
   lastName,
-  emailVerified
+  emailVerified,
+  externalId,
+  metadata
 ) {
   /**
    * Generates the CreateUserOptions object.
@@ -42,6 +48,8 @@ class CreateUserOptionsBuilder @JvmOverloads constructor(
       firstName = this.firstName,
       lastName = this.lastName,
       emailVerified = this.emailVerified,
+      externalId = this.externalId,
+      metadata = this.metadata
     )
   }
 

--- a/src/main/kotlin/com/workos/usermanagement/builders/UpdateUserOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/UpdateUserOptionsBuilder.kt
@@ -14,6 +14,8 @@ import com.workos.usermanagement.types.UpdateUserOptions
  * @param password The password to set for the user.
  * @param passwordHash The hashed password to set for the user. Mutually exclusive with password.
  * @param passwordHashType The algorithm originally used to hash the password, used when providing a password_hash.
+ * @param externalId The external ID of the user.
+ * @param metadata Object containing metadata key/value pairs associated with the user.
  */
 class UpdateUserOptionsBuilder @JvmOverloads constructor(
   val id: String,
@@ -24,13 +26,17 @@ class UpdateUserOptionsBuilder @JvmOverloads constructor(
   override var password: String? = null,
   override var passwordHash: String? = null,
   override var passwordHashType: PasswordHashTypeEnumType? = null,
+  override var externalId: String? = null,
+  override var metadata: Map<String, String>? = null,
 ) : AbstractUserOptionsBuilder<UpdateUserOptions>(
   password,
   passwordHash,
   passwordHashType,
   firstName,
   lastName,
-  emailVerified
+  emailVerified,
+  externalId,
+  metadata
 ) {
   /**
    * Generates the UpdateUserOptions object.
@@ -45,6 +51,8 @@ class UpdateUserOptionsBuilder @JvmOverloads constructor(
       password = this.password,
       passwordHash = this.passwordHash,
       passwordHashType = this.passwordHashType,
+      externalId = this.externalId,
+      metadata = this.metadata
     )
   }
 

--- a/src/main/kotlin/com/workos/usermanagement/models/User.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/User.kt
@@ -15,6 +15,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param lastSignInAt The timestamp when the user last signed in.
  * @param createdAt The timestamp when the user was created.
  * @param updatedAt The timestamp when the user was last updated.
+ * @param externalId The external ID of the user.
+ * @param metadata Object containing metadata key/value pairs associated with the user.
  */
 data class User @JsonCreator constructor(
   @JsonProperty("id")
@@ -42,5 +44,11 @@ data class User @JsonCreator constructor(
   val createdAt: String,
 
   @JsonProperty("updated_at")
-  val updatedAt: String
+  val updatedAt: String,
+
+  @JsonProperty("external_id")
+  val externalId: String? = null,
+
+  @JsonProperty("metadata")
+  val metadata: Map<String, String>,
 )

--- a/src/main/kotlin/com/workos/usermanagement/models/UserResponse.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/UserResponse.kt
@@ -1,0 +1,15 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A response containing a WorkOS user.
+ *
+ * @param user The corresponding user object.
+ */
+data class UserResponse @JsonCreator constructor(
+
+  @JsonProperty("user")
+  val user: User,
+)

--- a/src/main/kotlin/com/workos/usermanagement/types/CreateUserOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/CreateUserOptions.kt
@@ -47,7 +47,19 @@ class CreateUserOptions @JvmOverloads constructor(
    * You should normally use the email verification flow to verify a user’s email address. However, if the user’s email was previously verified, or is being migrated from an existing user store, this can be set to true to mark it as already verified.
    */
   @JsonProperty("email_verified")
-  val emailVerified: Boolean? = null
+  val emailVerified: Boolean? = null,
+
+  /**
+   * The external ID of the user.
+   */
+  @JsonProperty("external_id")
+  val externalId: String? = null,
+
+  /**
+   * Object containing metadata key/value pairs associated with the user.
+   */
+  @JsonProperty("metadata")
+  val metadata: Map<String, String>? = null
 ) {
   init {
     require(email.isNotBlank()) { "Email is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/UpdateUserOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/UpdateUserOptions.kt
@@ -51,7 +51,19 @@ class UpdateUserOptions @JvmOverloads constructor(
    * The algorithm originally used to hash the password, used when providing a password_hash.
    */
   @JsonProperty("password_hash_type")
-  val passwordHashType: PasswordHashTypeEnumType? = null
+  val passwordHashType: PasswordHashTypeEnumType? = null,
+
+  /**
+   * The external ID of the user.
+   */
+  @JsonProperty("external_id")
+  val externalId: String? = null,
+
+  /**
+   * Object containing metadata key/value pairs associated with the user.
+   */
+  @JsonProperty("metadata")
+  val metadata: Map<String, String>? = null
 ) {
   init {
     require(id.isNotBlank()) { "User id is required" }

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -53,7 +53,11 @@ class UserManagementApiTest : TestBase() {
         "last_name": "User",
         "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z"
+        "updated_at": "2021-06-25T19:07:33.155Z",
+        "external_id": "external_123",
+        "metadata": {
+          "language": "en"
+        }
       }"""
     )
 
@@ -69,7 +73,9 @@ class UserManagementApiTest : TestBase() {
         "https://example.com/profile_picture.jpg",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
+        "external_123",
+        mapOf("language" to "en"),
       ),
       user
     )
@@ -87,7 +93,8 @@ class UserManagementApiTest : TestBase() {
             "email": "test01@example.com",
             "last_sign_in_at": "2021-06-25T19:07:33.155Z",
             "created_at": "2021-06-25T19:07:33.155Z",
-            "updated_at": "2021-06-25T19:07:33.155Z"
+            "updated_at": "2021-06-25T19:07:33.155Z",
+            "metadata": {}
           }
         ],
         "list_metadata": {
@@ -109,7 +116,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
+        null,
+        emptyMap(),
       ),
       users.data[0]
     )
@@ -128,7 +137,8 @@ class UserManagementApiTest : TestBase() {
             "email": "test01@example.com",
             "last_sign_in_at": "2021-06-25T19:07:33.155Z",
             "created_at": "2021-06-25T19:07:33.155Z",
-            "updated_at": "2021-06-25T19:07:33.155Z"
+            "updated_at": "2021-06-25T19:07:33.155Z",
+            "metadata": {}
           }
         ],
         "list_metadata": {
@@ -160,7 +170,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
+        null,
+        emptyMap(),
       ),
       users.data[0]
     )
@@ -181,7 +193,11 @@ class UserManagementApiTest : TestBase() {
         "last_name": "User",
         "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z"
+        "updated_at": "2021-06-25T19:07:33.155Z",
+        "external_id": "external_123",
+        "metadata": {
+          "language": "en"
+        }
       }""",
       requestBody =
       """{
@@ -189,7 +205,11 @@ class UserManagementApiTest : TestBase() {
         "password": "password",
         "first_name": "Test",
         "last_name": "User",
-        "email_verified": true
+        "email_verified": true,
+        "external_id": "external_123",
+        "metadata": {
+          "language": "en"
+        }
       }"""
     )
 
@@ -199,6 +219,8 @@ class UserManagementApiTest : TestBase() {
         .firstName("Test")
         .lastName("User")
         .emailVerified(true)
+        .externalId("external_123")
+        .metadata(mapOf("language" to "en"))
         .build()
 
     val user = workos.userManagement.createUser(options)
@@ -213,7 +235,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
+        "external_123",
+        mapOf("language" to "en"),
       ),
       user
     )
@@ -233,7 +257,11 @@ class UserManagementApiTest : TestBase() {
         "last_name": "User",
         "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z"
+        "updated_at": "2021-06-25T19:07:33.155Z",
+        "external_id": "external_123",
+        "metadata": {
+          "language": "en"
+        }
       }""",
       requestBody =
       """{
@@ -241,7 +269,11 @@ class UserManagementApiTest : TestBase() {
         "password": "password",
         "first_name": "Test",
         "last_name": "User",
-        "email_verified": true
+        "email_verified": true,
+        "external_id": "external_123",
+        "metadata": {
+          "language": "en"
+        }
       }"""
     )
 
@@ -251,6 +283,8 @@ class UserManagementApiTest : TestBase() {
         .firstName("Test")
         .lastName("User")
         .emailVerified(true)
+        .externalId("external_123")
+        .metadata(mapOf("language" to "en"))
         .build()
 
     val user = workos.userManagement.updateUser("user_123", options)
@@ -265,7 +299,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
+        "external_123",
+        mapOf("language" to "en"),
       ),
       user
     )
@@ -410,7 +446,8 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
         "organization_id": "org_456",
         "access_token": "access_token",
@@ -460,7 +497,8 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
         "organization_id": "org_456",
         "access_token": "access_token",
@@ -510,7 +548,8 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
         "organization_id": "org_456",
         "access_token": "access_token",
@@ -558,9 +597,11 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
-        "organization_id": "org_456"
+        "organization_id": "org_456",
+        "metadata": {}
       }""",
       requestBody =
       """{
@@ -639,7 +680,8 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
         "organization_id": "org_456"
       }""",
@@ -685,7 +727,8 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
         "organization_id": "org_456"
       }""",
@@ -733,7 +776,8 @@ class UserManagementApiTest : TestBase() {
           "email_verified": true,
           "profile_picture_url": null,
           "created_at": "2021-06-25T19:07:33.155Z",
-          "updated_at": "2021-06-25T19:07:33.155Z"
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
         },
         "organization_id": "org_456"
       }""",
@@ -1094,7 +1138,8 @@ class UserManagementApiTest : TestBase() {
         "last_name": "User",
         "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z"
+        "updated_at": "2021-06-25T19:07:33.155Z",
+        "metadata": {}
       }""",
       requestBody =
       """{
@@ -1115,7 +1160,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
+        null,
+        emptyMap()
       ),
       user
     )

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -1129,17 +1129,19 @@ class UserManagementApiTest : TestBase() {
     stubResponse(
       "/user_management/password_reset/confirm",
       """{
-        "object": "user",
-        "id": "user_123",
-        "email": "test01@example.com",
-        "email_verified": true,
-        "profile_picture_url": null,
-        "first_name": "Test",
-        "last_name": "User",
-        "last_sign_in_at": "2021-06-25T19:07:33.155Z",
-        "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z",
-        "metadata": {}
+        "user": {
+          "object": "user",
+          "id": "user_123",
+          "email": "test01@example.com",
+          "email_verified": true,
+          "profile_picture_url": null,
+          "first_name": "Test",
+          "last_name": "User",
+          "last_sign_in_at": "2021-06-25T19:07:33.155Z",
+          "created_at": "2021-06-25T19:07:33.155Z",
+          "updated_at": "2021-06-25T19:07:33.155Z",
+          "metadata": {}
+        }
       }""",
       requestBody =
       """{

--- a/src/test/kotlin/com/workos/test/webhooks/UserWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/UserWebhookTests.kt
@@ -28,7 +28,9 @@ class UserWebhookTests : TestBase() {
         "profile_picture_url": "https://example.com/profile.jpg",
         "last_sign_in_at": "2023-11-27T18:00:00.000Z",
         "created_at": "2023-11-27T19:07:33.155Z",
-        "updated_at": "2023-11-27T19:07:33.155Z"
+        "updated_at": "2023-11-27T19:07:33.155Z",
+        "external_id": null,
+        "metadata": {}
       },
       "created_at": "2023-11-27T19:07:33.155Z"
     }


### PR DESCRIPTION
## Description

Some models in this library were out-to-date compared with [API Reference](https://workos.com/docs/reference). This PR is just normalizing this lib with the follow items according to the documentation

### User
Added the fields external id and metadata.

### Organization
Added the fields stripe customer id, external id and metadata.

### Password Reset
Fixed password reset call in UserManagementApi, which was throwing a parse exception due to inconsistency in the json returned in the response (the user object returns inside a property called "user")

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
