### PR TITLE
Update Nexus publishing endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -162,8 +162,9 @@ publishing {
 nexusPublishing {
   repositories {
     create("myNexus") {
-      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+      // Central Portal compatibility endpoints (post-OSSRH EOL June 30, 2025)
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
   }
 }


### PR DESCRIPTION
## Description

Update Nexus publishing endpoints to fix release action.

To test this, I ran a [release](https://github.com/workos/workos-kotlin/actions/runs/18386615573) and it [succeeded](https://central.sonatype.com/artifact/com.workos/workos/4.15.0)

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
