### PR TITLE
Add ability to resend invitation

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -476,6 +476,11 @@ class UserManagementApi(private val workos: WorkOS) {
     return workos.post("/user_management/invitations/$id/revoke", Invitation::class.java)
   }
 
+  /** Resends an existing invitation. */
+  fun resendInvitation(id: String): Invitation {
+    return workos.post("/user_management/invitations/$id/resend", Invitation::class.java)
+  }
+
   /** End a user's session. The user's browser should be redirected to this URL. */
   fun getLogoutUrl(sessionId: String, returnTo: String? = null): String {
     return URIBuilder(workos.baseUrl)


### PR DESCRIPTION
Toward AUTH-5516.

## Description

This adds support for the new resend invitation endpoint.

It can be used like this:

```java
workos.userManagement.resendInvitation("invitation_123")
```

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/47145
