### PR TITLE
Add organization webhook events (created, updated, deleted)

### DIFF
--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -172,6 +172,21 @@ enum class EventType(
   OrganizationMembershipUpdated("organization_membership.updated"),
 
   /**
+   * Triggers when an organization is created.
+   */
+  OrganizationCreated("organization.created"),
+
+  /**
+   * Triggers when an organization is updated.
+   */
+  OrganizationUpdated("organization.updated"),
+
+  /**
+   * Triggers when an organization is deleted.
+   */
+  OrganizationDeleted("organization.deleted"),
+
+  /**
    * Triggers when a user requests to reset their password.
    */
   PasswordResetCreated("password_reset.created"),

--- a/src/main/kotlin/com/workos/webhooks/models/OrganizationCreatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/OrganizationCreatedEvent.kt
@@ -1,0 +1,21 @@
+package com.workos.webhooks.models
+
+import com.workos.organizations.models.Organization
+
+/**
+ * Webhook Event for `organization.created`.
+ */
+class OrganizationCreatedEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: Organization,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)
+

--- a/src/main/kotlin/com/workos/webhooks/models/OrganizationDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/OrganizationDeletedEvent.kt
@@ -1,0 +1,21 @@
+package com.workos.webhooks.models
+
+import com.workos.organizations.models.Organization
+
+/**
+ * Webhook Event for `organization.deleted`.
+ */
+class OrganizationDeletedEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: Organization,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)
+

--- a/src/main/kotlin/com/workos/webhooks/models/OrganizationUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/OrganizationUpdatedEvent.kt
@@ -1,0 +1,21 @@
+package com.workos.webhooks.models
+
+import com.workos.organizations.models.Organization
+
+/**
+ * Webhook Event for `organization.updated`.
+ */
+class OrganizationUpdatedEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: Organization,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)
+

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.workos.directorysync.models.Directory
 import com.workos.directorysync.models.Group
 import com.workos.directorysync.models.User
+import com.workos.organizations.models.Organization
 import com.workos.sso.models.Connection
 import com.workos.usermanagement.models.AuthenticationEventData
 import com.workos.usermanagement.models.EmailVerificationEventData
@@ -73,6 +74,9 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.OrganizationMembershipCreated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipDeleted -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
+      EventType.OrganizationCreated -> OrganizationCreatedEvent(id, eventType, deserializeData(data, Organization::class.java), createdAt)
+      EventType.OrganizationUpdated -> OrganizationUpdatedEvent(id, eventType, deserializeData(data, Organization::class.java), createdAt)
+      EventType.OrganizationDeleted -> OrganizationDeletedEvent(id, eventType, deserializeData(data, Organization::class.java), createdAt)
       EventType.PasswordResetCreated -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
       EventType.PasswordResetSucceeded -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
       EventType.UserCreated -> UserCreatedEvent(id, eventType, deserializeData(data, UserManagementUser::class.java), createdAt)

--- a/src/test/kotlin/com/workos/test/webhooks/OrganizationWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/OrganizationWebhookTests.kt
@@ -1,0 +1,99 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EventType
+import com.workos.webhooks.models.OrganizationCreatedEvent
+import com.workos.webhooks.models.OrganizationUpdatedEvent
+import com.workos.webhooks.models.OrganizationDeletedEvent
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class OrganizationWebhookTests : TestBase() {
+
+  private val organizationId = "org_01EHWNCE74X7JSDV0X3SZ3KJNY"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "object": "organization",
+        "id": "$organizationId",
+        "name": "Test Organization",
+        "allow_profiles_outside_organization": false,
+        "domains": [
+          {
+            "object": "organization_domain",
+            "id": "org_domain_01H7ZGXFP5C6BBQY6Z7277ZCT0",
+            "domain": "example.com",
+            "state": "verified",
+            "verification_strategy": "dns",
+            "verification_token": "abc123"
+          }
+        ],
+        "created_at": "2023-11-27T19:07:33.155Z",
+        "updated_at": "2023-11-27T19:07:33.155Z"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructOrganizationCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationCreatedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationCreatedEvent).data.id, organizationId)
+    assertEquals(webhook.data.name, "Test Organization")
+  }
+
+  @Test
+  fun constructOrganizationUpdatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationUpdated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationUpdatedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationUpdatedEvent).data.id, organizationId)
+    assertEquals(webhook.data.name, "Test Organization")
+  }
+
+  @Test
+  fun constructOrganizationDeletedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationDeleted)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationDeletedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationDeletedEvent).data.id, organizationId)
+    assertEquals(webhook.data.name, "Test Organization")
+  }
+}
+


### PR DESCRIPTION
## Description
- Add OrganizationCreated, OrganizationUpdated, and OrganizationDeleted event types
- Create OrganizationCreatedEvent, OrganizationUpdatedEvent, and OrganizationDeletedEvent classes
- Update WebhookJsonDeserializer to handle organization events
- Add comprehensive tests for all three organization webhook events
- All tests passing
## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
