### PR TITLE
feat: Add custom_attributes field to OrganizationMembership

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
@@ -44,5 +44,5 @@ data class OrganizationMembership @JsonCreator constructor(
   val updatedAt: String,
 
   @JsonProperty("custom_attributes")
-  val customAttributes: Map<String, Any>? = null
+  val customAttributes: Map<String, Any> = emptyMap()
 )


### PR DESCRIPTION
## Summary

Adds `custom_attributes` field to `OrganizationMembership` model to expose custom attributes from identity providers.

## Changes

- Added `custom_attributes` field to OrganizationMembership type/model
- Field type: Record/Map/Dictionary of string keys to any values
- Always present, defaults to empty object `{}`
- Updated fixtures and tests

## API Field Details

The field will be present in:
- REST API responses
- Webhook events
- Events API responses

JSON field name: `custom_attributes` (snake_case)