### PR TITLE
feat: Add email field to DirectoryUser

### DIFF
--- a/src/main/kotlin/com/workos/directorysync/models/User.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/User.kt
@@ -46,6 +46,9 @@ open class User
   @JsonProperty("idp_id")
   open val idpId: String,
 
+  @JvmField
+  open val email: String?,
+
   @Deprecated(
     "Will be removed in a future major version. Enable the `username` custom attribute in dashboard and pull from customAttributes instead. See https://workos.com/docs/directory-sync/attributes/custom-attributes/auto-mapped-attributes for details.",
     ReplaceWith("customAttributes[\"username\"]")

--- a/src/test/kotlin/com/workos/test/directorysync/UserTest.kt
+++ b/src/test/kotlin/com/workos/test/directorysync/UserTest.kt
@@ -53,6 +53,7 @@ class UserTest : TestBase() {
       }"""
     )
     val directoryUser = workos.directorySync.getDirectoryUser(userId)
+    assertEquals(directoryUser.email, "marcelina1@foo-corp.com")
     assertEquals(directoryUser.primaryEmail(), "marcelina1@foo-corp.com")
   }
 }


### PR DESCRIPTION
## Description

Add the email property to the User class that was intended in PR #270. The field was missing from the constructor even though it was documented, tested in the JSON fixture, and the deprecated `primaryEmail()` method was updated to reference it. This adds the property and includes a test assertion to verify proper deserialization.

Resolves #320.

## Documentation

```
[ ] Yes
```