### PR TITLE
feat: [ENT-4372] Add authorization models, types, and builders

### DIFF
--- a/src/main/kotlin/com/workos/authorization/builders/AssignRoleOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/AssignRoleOptionsBuilder.kt
@@ -1,0 +1,34 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.AssignRoleOptions
+
+class AssignRoleOptionsBuilder @JvmOverloads constructor(
+  private var roleSlug: String,
+  private var resourceId: String? = null,
+  private var resourceExternalId: String? = null,
+  private var resourceTypeSlug: String? = null
+) {
+  fun roleSlug(value: String) = apply { roleSlug = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun resourceExternalId(value: String) = apply { resourceExternalId = value }
+
+  fun resourceTypeSlug(value: String) = apply { resourceTypeSlug = value }
+
+  fun build(): AssignRoleOptions {
+    return AssignRoleOptions(
+      roleSlug = this.roleSlug,
+      resourceId = this.resourceId,
+      resourceExternalId = this.resourceExternalId,
+      resourceTypeSlug = this.resourceTypeSlug
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(roleSlug: String): AssignRoleOptionsBuilder {
+      return AssignRoleOptionsBuilder(roleSlug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/CheckAuthorizationOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/CheckAuthorizationOptionsBuilder.kt
@@ -1,0 +1,34 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.CheckAuthorizationOptions
+
+class CheckAuthorizationOptionsBuilder @JvmOverloads constructor(
+  private var permissionSlug: String,
+  private var resourceId: String? = null,
+  private var resourceExternalId: String? = null,
+  private var resourceTypeSlug: String? = null
+) {
+  fun permissionSlug(value: String) = apply { permissionSlug = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun resourceExternalId(value: String) = apply { resourceExternalId = value }
+
+  fun resourceTypeSlug(value: String) = apply { resourceTypeSlug = value }
+
+  fun build(): CheckAuthorizationOptions {
+    return CheckAuthorizationOptions(
+      permissionSlug = this.permissionSlug,
+      resourceId = this.resourceId,
+      resourceExternalId = this.resourceExternalId,
+      resourceTypeSlug = this.resourceTypeSlug
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(permissionSlug: String): CheckAuthorizationOptionsBuilder {
+      return CheckAuthorizationOptionsBuilder(permissionSlug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/CreateAuthorizationResourceOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/CreateAuthorizationResourceOptionsBuilder.kt
@@ -1,0 +1,50 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.CreateAuthorizationResourceOptions
+
+class CreateAuthorizationResourceOptionsBuilder @JvmOverloads constructor(
+  private var organizationId: String,
+  private var resourceTypeSlug: String,
+  private var externalId: String,
+  private var name: String,
+  private var description: String? = null,
+  private var parentResourceId: String? = null,
+  private var parentResourceExternalId: String? = null,
+  private var parentResourceTypeSlug: String? = null
+) {
+  fun organizationId(value: String) = apply { organizationId = value }
+
+  fun resourceTypeSlug(value: String) = apply { resourceTypeSlug = value }
+
+  fun externalId(value: String) = apply { externalId = value }
+
+  fun name(value: String) = apply { name = value }
+
+  fun description(value: String) = apply { description = value }
+
+  fun parentResourceId(value: String) = apply { parentResourceId = value }
+
+  fun parentResourceExternalId(value: String) = apply { parentResourceExternalId = value }
+
+  fun parentResourceTypeSlug(value: String) = apply { parentResourceTypeSlug = value }
+
+  fun build(): CreateAuthorizationResourceOptions {
+    return CreateAuthorizationResourceOptions(
+      organizationId = this.organizationId,
+      resourceTypeSlug = this.resourceTypeSlug,
+      externalId = this.externalId,
+      name = this.name,
+      description = this.description,
+      parentResourceId = this.parentResourceId,
+      parentResourceExternalId = this.parentResourceExternalId,
+      parentResourceTypeSlug = this.parentResourceTypeSlug
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(organizationId: String, resourceTypeSlug: String, externalId: String, name: String): CreateAuthorizationResourceOptionsBuilder {
+      return CreateAuthorizationResourceOptionsBuilder(organizationId, resourceTypeSlug, externalId, name)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/ListAuthorizationResourcesOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/ListAuthorizationResourcesOptionsBuilder.kt
@@ -1,0 +1,59 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.ListAuthorizationResourcesOptions
+import com.workos.common.models.Order
+
+class ListAuthorizationResourcesOptionsBuilder @JvmOverloads constructor(
+  private var organizationId: String? = null,
+  private var resourceTypeSlug: String? = null,
+  private var parentResourceId: String? = null,
+  private var parentResourceTypeSlug: String? = null,
+  private var parentExternalId: String? = null,
+  private var search: String? = null,
+  private var limit: Int? = null,
+  private var order: Order? = null,
+  private var before: String? = null,
+  private var after: String? = null
+) {
+  fun organizationId(value: String) = apply { organizationId = value }
+
+  fun resourceTypeSlug(value: String) = apply { resourceTypeSlug = value }
+
+  fun parentResourceId(value: String) = apply { parentResourceId = value }
+
+  fun parentResourceTypeSlug(value: String) = apply { parentResourceTypeSlug = value }
+
+  fun parentExternalId(value: String) = apply { parentExternalId = value }
+
+  fun search(value: String) = apply { search = value }
+
+  fun limit(value: Int) = apply { limit = value }
+
+  fun order(value: Order) = apply { order = value }
+
+  fun before(value: String) = apply { before = value }
+
+  fun after(value: String) = apply { after = value }
+
+  fun build(): ListAuthorizationResourcesOptions {
+    return ListAuthorizationResourcesOptions(
+      organizationId = this.organizationId,
+      resourceTypeSlug = this.resourceTypeSlug,
+      parentResourceId = this.parentResourceId,
+      parentResourceTypeSlug = this.parentResourceTypeSlug,
+      parentExternalId = this.parentExternalId,
+      search = this.search,
+      limit = this.limit,
+      order = this.order,
+      before = this.before,
+      after = this.after
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(): ListAuthorizationResourcesOptionsBuilder {
+      return ListAuthorizationResourcesOptionsBuilder()
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/ListMembershipsForResourceByExternalIdOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/ListMembershipsForResourceByExternalIdOptionsBuilder.kt
@@ -1,0 +1,44 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.AssignmentFilter
+import com.workos.authorization.types.ListMembershipsForResourceByExternalIdOptions
+import com.workos.common.models.Order
+
+class ListMembershipsForResourceByExternalIdOptionsBuilder @JvmOverloads constructor(
+  private var permissionSlug: String,
+  private var assignment: AssignmentFilter? = null,
+  private var limit: Int? = null,
+  private var order: Order? = null,
+  private var before: String? = null,
+  private var after: String? = null
+) {
+  fun permissionSlug(value: String) = apply { permissionSlug = value }
+
+  fun assignment(value: AssignmentFilter) = apply { assignment = value }
+
+  fun limit(value: Int) = apply { limit = value }
+
+  fun order(value: Order) = apply { order = value }
+
+  fun before(value: String) = apply { before = value }
+
+  fun after(value: String) = apply { after = value }
+
+  fun build(): ListMembershipsForResourceByExternalIdOptions {
+    return ListMembershipsForResourceByExternalIdOptions(
+      permissionSlug = this.permissionSlug,
+      assignment = this.assignment,
+      limit = this.limit,
+      order = this.order,
+      before = this.before,
+      after = this.after
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(permissionSlug: String): ListMembershipsForResourceByExternalIdOptionsBuilder {
+      return ListMembershipsForResourceByExternalIdOptionsBuilder(permissionSlug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/ListMembershipsForResourceOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/ListMembershipsForResourceOptionsBuilder.kt
@@ -1,0 +1,44 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.AssignmentFilter
+import com.workos.authorization.types.ListMembershipsForResourceOptions
+import com.workos.common.models.Order
+
+class ListMembershipsForResourceOptionsBuilder @JvmOverloads constructor(
+  private var permissionSlug: String,
+  private var assignment: AssignmentFilter? = null,
+  private var limit: Int? = null,
+  private var order: Order? = null,
+  private var before: String? = null,
+  private var after: String? = null
+) {
+  fun permissionSlug(value: String) = apply { permissionSlug = value }
+
+  fun assignment(value: AssignmentFilter) = apply { assignment = value }
+
+  fun limit(value: Int) = apply { limit = value }
+
+  fun order(value: Order) = apply { order = value }
+
+  fun before(value: String) = apply { before = value }
+
+  fun after(value: String) = apply { after = value }
+
+  fun build(): ListMembershipsForResourceOptions {
+    return ListMembershipsForResourceOptions(
+      permissionSlug = this.permissionSlug,
+      assignment = this.assignment,
+      limit = this.limit,
+      order = this.order,
+      before = this.before,
+      after = this.after
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(permissionSlug: String): ListMembershipsForResourceOptionsBuilder {
+      return ListMembershipsForResourceOptionsBuilder(permissionSlug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/ListResourcesForMembershipOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/ListResourcesForMembershipOptionsBuilder.kt
@@ -1,0 +1,55 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.ListResourcesForMembershipOptions
+import com.workos.common.models.Order
+
+class ListResourcesForMembershipOptionsBuilder @JvmOverloads constructor(
+  private var permissionSlug: String,
+  private var parentResourceId: String? = null,
+  private var parentResourceTypeSlug: String? = null,
+  private var parentResourceExternalId: String? = null,
+  private var resourceTypeSlug: String? = null,
+  private var limit: Int? = null,
+  private var order: Order? = null,
+  private var before: String? = null,
+  private var after: String? = null
+) {
+  fun permissionSlug(value: String) = apply { permissionSlug = value }
+
+  fun parentResourceId(value: String) = apply { parentResourceId = value }
+
+  fun parentResourceTypeSlug(value: String) = apply { parentResourceTypeSlug = value }
+
+  fun parentResourceExternalId(value: String) = apply { parentResourceExternalId = value }
+
+  fun resourceTypeSlug(value: String) = apply { resourceTypeSlug = value }
+
+  fun limit(value: Int) = apply { limit = value }
+
+  fun order(value: Order) = apply { order = value }
+
+  fun before(value: String) = apply { before = value }
+
+  fun after(value: String) = apply { after = value }
+
+  fun build(): ListResourcesForMembershipOptions {
+    return ListResourcesForMembershipOptions(
+      permissionSlug = this.permissionSlug,
+      parentResourceId = this.parentResourceId,
+      parentResourceTypeSlug = this.parentResourceTypeSlug,
+      parentResourceExternalId = this.parentResourceExternalId,
+      resourceTypeSlug = this.resourceTypeSlug,
+      limit = this.limit,
+      order = this.order,
+      before = this.before,
+      after = this.after
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(permissionSlug: String): ListResourcesForMembershipOptionsBuilder {
+      return ListResourcesForMembershipOptionsBuilder(permissionSlug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/ListRoleAssignmentsOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/ListRoleAssignmentsOptionsBuilder.kt
@@ -1,0 +1,35 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.ListRoleAssignmentsOptions
+import com.workos.common.models.Order
+
+class ListRoleAssignmentsOptionsBuilder @JvmOverloads constructor(
+  private var limit: Int? = null,
+  private var order: Order? = null,
+  private var before: String? = null,
+  private var after: String? = null
+) {
+  fun limit(value: Int) = apply { limit = value }
+
+  fun order(value: Order) = apply { order = value }
+
+  fun before(value: String) = apply { before = value }
+
+  fun after(value: String) = apply { after = value }
+
+  fun build(): ListRoleAssignmentsOptions {
+    return ListRoleAssignmentsOptions(
+      limit = this.limit,
+      order = this.order,
+      before = this.before,
+      after = this.after
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(): ListRoleAssignmentsOptionsBuilder {
+      return ListRoleAssignmentsOptionsBuilder()
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/RemoveRoleOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/RemoveRoleOptionsBuilder.kt
@@ -1,0 +1,34 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.RemoveRoleOptions
+
+class RemoveRoleOptionsBuilder @JvmOverloads constructor(
+  private var roleSlug: String,
+  private var resourceId: String? = null,
+  private var resourceExternalId: String? = null,
+  private var resourceTypeSlug: String? = null
+) {
+  fun roleSlug(value: String) = apply { roleSlug = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun resourceExternalId(value: String) = apply { resourceExternalId = value }
+
+  fun resourceTypeSlug(value: String) = apply { resourceTypeSlug = value }
+
+  fun build(): RemoveRoleOptions {
+    return RemoveRoleOptions(
+      roleSlug = this.roleSlug,
+      resourceId = this.resourceId,
+      resourceExternalId = this.resourceExternalId,
+      resourceTypeSlug = this.resourceTypeSlug
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(roleSlug: String): RemoveRoleOptionsBuilder {
+      return RemoveRoleOptionsBuilder(roleSlug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/builders/UpdateAuthorizationResourceOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/authorization/builders/UpdateAuthorizationResourceOptionsBuilder.kt
@@ -1,0 +1,26 @@
+package com.workos.authorization.builders
+
+import com.workos.authorization.types.UpdateAuthorizationResourceOptions
+
+class UpdateAuthorizationResourceOptionsBuilder @JvmOverloads constructor(
+  private var name: String? = null,
+  private var description: String? = null
+) {
+  fun name(value: String) = apply { name = value }
+
+  fun description(value: String) = apply { description = value }
+
+  fun build(): UpdateAuthorizationResourceOptions {
+    return UpdateAuthorizationResourceOptions(
+      name = this.name,
+      description = this.description
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(): UpdateAuthorizationResourceOptionsBuilder {
+      return UpdateAuthorizationResourceOptionsBuilder()
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/models/AuthorizationCheckResult.kt
+++ b/src/main/kotlin/com/workos/authorization/models/AuthorizationCheckResult.kt
@@ -1,0 +1,9 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class AuthorizationCheckResult
+@JsonCreator constructor(
+  @JvmField
+  val authorized: Boolean
+)

--- a/src/main/kotlin/com/workos/authorization/models/AuthorizationOrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/authorization/models/AuthorizationOrganizationMembership.kt
@@ -1,0 +1,37 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AuthorizationOrganizationMembership
+@JsonCreator constructor(
+  @JvmField
+  @JsonProperty("object")
+  val obj: String = "organization_membership",
+
+  @JvmField
+  val id: String,
+
+  @JvmField
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JvmField
+  @JsonProperty("organization_id")
+  val organizationId: String,
+
+  @JvmField
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JvmField
+  @JsonProperty("updated_at")
+  val updatedAt: String,
+
+  @JvmField
+  val status: String? = null,
+
+  @JvmField
+  @JsonProperty("custom_attributes")
+  val customAttributes: Map<String, Any>? = null
+)

--- a/src/main/kotlin/com/workos/authorization/models/AuthorizationOrganizationMembershipList.kt
+++ b/src/main/kotlin/com/workos/authorization/models/AuthorizationOrganizationMembershipList.kt
@@ -1,0 +1,15 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.ListMetadata
+
+data class AuthorizationOrganizationMembershipList
+@JsonCreator constructor(
+  @JvmField
+  val data: List<AuthorizationOrganizationMembership>,
+
+  @JvmField
+  @JsonProperty("list_metadata")
+  val listMetadata: ListMetadata
+)

--- a/src/main/kotlin/com/workos/authorization/models/AuthorizationResource.kt
+++ b/src/main/kotlin/com/workos/authorization/models/AuthorizationResource.kt
@@ -1,0 +1,44 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AuthorizationResource
+@JsonCreator constructor(
+  @JvmField
+  @JsonProperty("object")
+  val obj: String = "authorization_resource",
+
+  @JvmField
+  val id: String,
+
+  @JvmField
+  @JsonProperty("external_id")
+  val externalId: String,
+
+  @JvmField
+  val name: String,
+
+  @JvmField
+  val description: String? = null,
+
+  @JvmField
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String,
+
+  @JvmField
+  @JsonProperty("organization_id")
+  val organizationId: String,
+
+  @JvmField
+  @JsonProperty("parent_resource_id")
+  val parentResourceId: String? = null,
+
+  @JvmField
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JvmField
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)

--- a/src/main/kotlin/com/workos/authorization/models/AuthorizationResourceList.kt
+++ b/src/main/kotlin/com/workos/authorization/models/AuthorizationResourceList.kt
@@ -1,0 +1,15 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.ListMetadata
+
+data class AuthorizationResourceList
+@JsonCreator constructor(
+  @JvmField
+  val data: List<AuthorizationResource>,
+
+  @JvmField
+  @JsonProperty("list_metadata")
+  val listMetadata: ListMetadata
+)

--- a/src/main/kotlin/com/workos/authorization/models/RoleAssignment.kt
+++ b/src/main/kotlin/com/workos/authorization/models/RoleAssignment.kt
@@ -1,0 +1,48 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class RoleAssignment
+@JsonCreator constructor(
+  @JvmField
+  @JsonProperty("object")
+  val obj: String = "role_assignment",
+
+  @JvmField
+  val id: String,
+
+  @JvmField
+  val role: RoleAssignmentRole,
+
+  @JvmField
+  val resource: RoleAssignmentResource,
+
+  @JvmField
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JvmField
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)
+
+data class RoleAssignmentRole
+@JsonCreator constructor(
+  @JvmField
+  val slug: String
+)
+
+data class RoleAssignmentResource
+@JsonCreator constructor(
+  @JvmField
+  val id: String,
+
+  @JvmField
+  @JsonProperty("external_id")
+  val externalId: String,
+
+  @JvmField
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String
+)

--- a/src/main/kotlin/com/workos/authorization/models/RoleAssignmentList.kt
+++ b/src/main/kotlin/com/workos/authorization/models/RoleAssignmentList.kt
@@ -1,0 +1,15 @@
+package com.workos.authorization.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.ListMetadata
+
+data class RoleAssignmentList
+@JsonCreator constructor(
+  @JvmField
+  val data: List<RoleAssignment>,
+
+  @JvmField
+  @JsonProperty("list_metadata")
+  val listMetadata: ListMetadata
+)

--- a/src/main/kotlin/com/workos/authorization/types/AssignRoleOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/AssignRoleOptions.kt
@@ -1,0 +1,29 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class AssignRoleOptions @JvmOverloads constructor(
+  @JsonProperty("role_slug")
+  val roleSlug: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String? = null,
+
+  @JsonProperty("resource_external_id")
+  val resourceExternalId: String? = null,
+
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String? = null
+) {
+  init {
+    require(roleSlug.isNotBlank()) { "roleSlug is required" }
+    require(!(resourceId != null && resourceExternalId != null)) {
+      "Cannot specify both resourceId and resourceExternalId"
+    }
+    require(!(resourceExternalId != null && resourceTypeSlug == null)) {
+      "resourceTypeSlug is required when resourceExternalId is specified"
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/AssignmentFilter.kt
+++ b/src/main/kotlin/com/workos/authorization/types/AssignmentFilter.kt
@@ -1,0 +1,10 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class AssignmentFilter(@JsonValue val value: String) {
+  Direct("direct"),
+  Inherited("inherited");
+
+  override fun toString(): String = value
+}

--- a/src/main/kotlin/com/workos/authorization/types/CheckAuthorizationOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/CheckAuthorizationOptions.kt
@@ -1,0 +1,29 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class CheckAuthorizationOptions @JvmOverloads constructor(
+  @JsonProperty("permission_slug")
+  val permissionSlug: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String? = null,
+
+  @JsonProperty("resource_external_id")
+  val resourceExternalId: String? = null,
+
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String? = null
+) {
+  init {
+    require(permissionSlug.isNotBlank()) { "permissionSlug is required" }
+    require(!(resourceId != null && resourceExternalId != null)) {
+      "Cannot specify both resourceId and resourceExternalId"
+    }
+    require(!(resourceExternalId != null && resourceTypeSlug == null)) {
+      "resourceTypeSlug is required when resourceExternalId is specified"
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/CreateAuthorizationResourceOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/CreateAuthorizationResourceOptions.kt
@@ -1,0 +1,42 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class CreateAuthorizationResourceOptions @JvmOverloads constructor(
+  @JsonProperty("organization_id")
+  val organizationId: String,
+
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String,
+
+  @JsonProperty("external_id")
+  val externalId: String,
+
+  @JsonProperty("name")
+  val name: String,
+
+  @JsonProperty("description")
+  val description: String? = null,
+
+  @JsonProperty("parent_resource_id")
+  val parentResourceId: String? = null,
+
+  @JsonProperty("parent_resource_external_id")
+  val parentResourceExternalId: String? = null,
+
+  @JsonProperty("parent_resource_type_slug")
+  val parentResourceTypeSlug: String? = null
+) {
+  init {
+    require(externalId.isNotBlank()) { "externalId is required" }
+    require(name.isNotBlank()) { "name is required" }
+    require(!(parentResourceId != null && parentResourceExternalId != null)) {
+      "Cannot specify both parentResourceId and parentResourceExternalId"
+    }
+    require(!(parentResourceExternalId != null && parentResourceTypeSlug == null)) {
+      "parentResourceTypeSlug is required when parentResourceExternalId is specified"
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/ListAuthorizationResourcesOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/ListAuthorizationResourcesOptions.kt
@@ -1,0 +1,38 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListAuthorizationResourcesOptions @JvmOverloads constructor(
+  @JsonProperty("organization_id")
+  val organizationId: String? = null,
+
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String? = null,
+
+  @JsonProperty("parent_resource_id")
+  val parentResourceId: String? = null,
+
+  @JsonProperty("parent_resource_type_slug")
+  val parentResourceTypeSlug: String? = null,
+
+  @JsonProperty("parent_external_id")
+  val parentExternalId: String? = null,
+
+  @JsonProperty("search")
+  val search: String? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+)

--- a/src/main/kotlin/com/workos/authorization/types/ListMembershipsForResourceByExternalIdOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/ListMembershipsForResourceByExternalIdOptions.kt
@@ -1,0 +1,30 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListMembershipsForResourceByExternalIdOptions @JvmOverloads constructor(
+  @JsonProperty("permission_slug")
+  val permissionSlug: String,
+
+  @JsonProperty("assignment")
+  val assignment: AssignmentFilter? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+) {
+  init {
+    require(permissionSlug.isNotBlank()) { "permissionSlug is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/ListMembershipsForResourceOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/ListMembershipsForResourceOptions.kt
@@ -1,0 +1,30 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListMembershipsForResourceOptions @JvmOverloads constructor(
+  @JsonProperty("permission_slug")
+  val permissionSlug: String,
+
+  @JsonProperty("assignment")
+  val assignment: AssignmentFilter? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+) {
+  init {
+    require(permissionSlug.isNotBlank()) { "permissionSlug is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/ListResourcesForMembershipOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/ListResourcesForMembershipOptions.kt
@@ -1,0 +1,42 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListResourcesForMembershipOptions @JvmOverloads constructor(
+  @JsonProperty("permission_slug")
+  val permissionSlug: String,
+
+  @JsonProperty("parent_resource_id")
+  val parentResourceId: String? = null,
+
+  @JsonProperty("parent_resource_type_slug")
+  val parentResourceTypeSlug: String? = null,
+
+  @JsonProperty("parent_resource_external_id")
+  val parentResourceExternalId: String? = null,
+
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+) {
+  init {
+    require(permissionSlug.isNotBlank()) { "permissionSlug is required" }
+    require(!(parentResourceId != null && parentResourceExternalId != null)) {
+      "Cannot specify both parentResourceId and parentResourceExternalId"
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/ListRoleAssignmentsOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/ListRoleAssignmentsOptions.kt
@@ -1,0 +1,20 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListRoleAssignmentsOptions @JvmOverloads constructor(
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+)

--- a/src/main/kotlin/com/workos/authorization/types/RemoveRoleOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/RemoveRoleOptions.kt
@@ -1,0 +1,29 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class RemoveRoleOptions @JvmOverloads constructor(
+  @JsonProperty("role_slug")
+  val roleSlug: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String? = null,
+
+  @JsonProperty("resource_external_id")
+  val resourceExternalId: String? = null,
+
+  @JsonProperty("resource_type_slug")
+  val resourceTypeSlug: String? = null
+) {
+  init {
+    require(roleSlug.isNotBlank()) { "roleSlug is required" }
+    require(!(resourceId != null && resourceExternalId != null)) {
+      "Cannot specify both resourceId and resourceExternalId"
+    }
+    require(!(resourceExternalId != null && resourceTypeSlug == null)) {
+      "resourceTypeSlug is required when resourceExternalId is specified"
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/authorization/types/UpdateAuthorizationResourceOptions.kt
+++ b/src/main/kotlin/com/workos/authorization/types/UpdateAuthorizationResourceOptions.kt
@@ -1,0 +1,13 @@
+package com.workos.authorization.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class UpdateAuthorizationResourceOptions @JvmOverloads constructor(
+  @JsonProperty("name")
+  val name: String? = null,
+
+  @JsonProperty("description")
+  val description: String? = null
+)


### PR DESCRIPTION
## Summary
- Add 7 model classes (AuthorizationResource, AuthorizationCheckResult, RoleAssignment, etc.)
- Add 10 options/types classes with validation (CreateAuthorizationResourceOptions, CheckAuthorizationOptions, etc.)
- Add 10 fluent builder classes for Java interop
- Add AssignmentFilter enum for membership query filtering

**Stack:** 2/7 — all data types used by the authorization API

## Test plan
- [ ] `./gradlew build` passes
- [ ] All models use `@JsonCreator`, `@JvmField`, `@JsonProperty` pattern
- [ ] Options classes have `init {}` validation blocks where applicable