### PR TITLE
feat: [ENT-4372] Add resource methods by external ID

### DIFF
--- a/src/main/kotlin/com/workos/authorization/AuthorizationApi.kt
+++ b/src/main/kotlin/com/workos/authorization/AuthorizationApi.kt
@@ -14,10 +14,7 @@ class AuthorizationApi(private val workos: WorkOS) {
 
   companion object {
     internal const val RESOURCES_PATH = "/authorization/resources"
-<<<<<<< HEAD
-=======
     internal const val ORGANIZATIONS_PATH = "/authorization/organizations"
->>>>>>> 7a820c1 (formatting, breaking up paths to common strings, add inner classes for tests)
     internal const val ORGANIZATION_MEMBERSHIPS_PATH = "/authorization/organization_memberships"
   }
 

--- a/src/test/kotlin/com/workos/test/authorization/AuthorizationApiTest.kt
+++ b/src/test/kotlin/com/workos/test/authorization/AuthorizationApiTest.kt
@@ -209,14 +209,7 @@ class AuthorizationApiTest : TestBase() {
       assertDoesNotThrow { workos.authorization.deleteResource("resource_01H", cascadeDelete = true) }
     }
   }
-<<<<<<< HEAD
 
-=======
-<<<<<<< HEAD
-=======
-
->>>>>>> 7a820c1 (formatting, breaking up paths to common strings, add inner classes for tests)
->>>>>>> aa590f7 (formatting, breaking up paths to common strings, add inner classes for tests)
   @Nested
   inner class ListResources {
     @Test


### PR DESCRIPTION
## Summary
- Add 3 methods: getResourceByExternalId, updateResourceByExternalId, deleteResourceByExternalId
- Operate via `/authorization/organizations/{orgId}/resources/{typeSlug}/{externalId}` endpoints
- deleteResourceByExternalId supports `cascade_delete` query parameter

**Stack:** 5/7 — resource CRUD by external ID

## Test plan
- [ ] 4 new tests pass
- [ ] `./gradlew test` passes