### PR TITLE
feat(user-management): add directoryManaged to OrganizationMembership

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
@@ -17,6 +17,7 @@ import com.workos.usermanagement.types.OrganizationMembershipStatusEnumType
  * @param createdAt The timestamp when the user was created.
  * @param updatedAt The timestamp when the user was last updated.
  * @param customAttributes Custom attributes from the identity provider.
+ * @param directoryManaged Whether the organization membership is managed by a directory sync connection.
  */
 data class OrganizationMembership @JsonCreator constructor(
   @JsonProperty("id")
@@ -44,5 +45,8 @@ data class OrganizationMembership @JsonCreator constructor(
   val updatedAt: String,
 
   @JsonProperty("custom_attributes")
-  val customAttributes: Map<String, Any> = emptyMap()
+  val customAttributes: Map<String, Any> = emptyMap(),
+
+  @JsonProperty("directory_managed")
+  val directoryManaged: Boolean = false
 )

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -1188,7 +1188,8 @@ class UserManagementApiTest : TestBase() {
         ],
         "status": "active",
         "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z"
+        "updated_at": "2021-06-25T19:07:33.155Z",
+        "directory_managed": false
       }"""
     )
 

--- a/src/test/kotlin/com/workos/test/webhooks/OrganizationMembershipWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/OrganizationMembershipWebhookTests.kt
@@ -24,7 +24,8 @@ class OrganizationMembershipWebhookTests : TestBase() {
         "organization_id": "org_01EHWNCE74X7JSDV0X3SZ3KJNY",
         "status": "active",
         "created_at": "2023-11-27T19:07:33.155Z",
-        "updated_at": "2023-11-27T19:07:33.155Z"
+        "updated_at": "2023-11-27T19:07:33.155Z",
+        "directory_managed": false
       },
       "created_at": "2023-11-27T19:07:33.155Z"
     }


### PR DESCRIPTION
## Summary
- Add `directoryManaged: Boolean` field with `@JsonProperty("directory_managed")` to `OrganizationMembership` data class
- Default value is `false` for backwards compatibility
- Update test fixtures to include `directory_managed` field

This field indicates whether an organization membership is managed by a directory sync connection.

## Test plan
- [x] Existing tests pass (`./gradlew test`)
- [x] New field is properly deserialized from JSON
🤖 Generated with [Claude Code](https://claude.com/claude-code)