### PR TITLE
fix: Add organization domain verification webhook events

### DIFF
--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -182,6 +182,31 @@ enum class EventType(
   PasswordResetSucceeded("password_reset.succeeded"),
 
   /**
+   * Triggers when an organization domain is created.
+   */
+  OrganizationDomainCreated("organization_domain.created"),
+
+  /**
+   * Triggers when an organization domain is updated.
+   */
+  OrganizationDomainUpdated("organization_domain.updated"),
+
+  /**
+   * Triggers when an organization domain is deleted.
+   */
+  OrganizationDomainDeleted("organization_domain.deleted"),
+
+  /**
+   * Triggers when an organization domain is verified.
+   */
+  OrganizationDomainVerified("organization_domain.verified"),
+
+  /**
+   * Triggers when an organization domain verification fails.
+   */
+  OrganizationDomainVerificationFailed("organization_domain.verification_failed"),
+
+  /**
    * Triggers when a user is created.
    */
   UserCreated("user.created"),

--- a/src/main/kotlin/com/workos/webhooks/models/OrganizationDomainEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/OrganizationDomainEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.organizations.models.OrganizationDomain
+
+/**
+ * Webhook Event for `organization_domain.*` events.
+ */
+class OrganizationDomainEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: OrganizationDomain,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.workos.directorysync.models.Directory
 import com.workos.directorysync.models.Group
 import com.workos.directorysync.models.User
+import com.workos.organizations.models.OrganizationDomain
 import com.workos.sso.models.Connection
 import com.workos.usermanagement.models.AuthenticationEventData
 import com.workos.usermanagement.models.EmailVerificationEventData
@@ -70,6 +71,11 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.InvitationCreated -> InvitationEvent(id, eventType, deserializeData(data, InvitationEventData::class.java), createdAt)
       EventType.InvitationRevoked -> InvitationEvent(id, eventType, deserializeData(data, InvitationEventData::class.java), createdAt)
       EventType.MagicAuthCreated -> MagicAuthEvent(id, eventType, deserializeData(data, MagicAuthEventData::class.java), createdAt)
+      EventType.OrganizationDomainCreated -> OrganizationDomainEvent(id, eventType, deserializeData(data, OrganizationDomain::class.java), createdAt)
+      EventType.OrganizationDomainUpdated -> OrganizationDomainEvent(id, eventType, deserializeData(data, OrganizationDomain::class.java), createdAt)
+      EventType.OrganizationDomainDeleted -> OrganizationDomainEvent(id, eventType, deserializeData(data, OrganizationDomain::class.java), createdAt)
+      EventType.OrganizationDomainVerified -> OrganizationDomainEvent(id, eventType, deserializeData(data, OrganizationDomain::class.java), createdAt)
+      EventType.OrganizationDomainVerificationFailed -> OrganizationDomainEvent(id, eventType, deserializeData(data, OrganizationDomain::class.java), createdAt)
       EventType.OrganizationMembershipCreated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipDeleted -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)

--- a/src/test/kotlin/com/workos/test/events/EventsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/events/EventsApiTest.kt
@@ -7,6 +7,7 @@ import com.workos.events.models.DirectoryEvent
 import com.workos.events.models.DirectoryGroupEvent
 import com.workos.events.models.DirectoryGroupMembershipEvent
 import com.workos.events.models.DirectoryUserEvent
+import com.workos.events.models.OrganizationDomainEvent
 import com.workos.events.models.OrganizationEvent
 import com.workos.test.TestBase
 import kotlin.test.Test
@@ -258,5 +259,86 @@ class EventsApiTest : TestBase() {
     assertIs<DirectoryUserEvent>(event)
     assertEquals("dsync.user.created", event.event)
     assertEquals("directory_user_01E1X56GH84T3FB41SD6PZGDBX", (event as DirectoryUserEvent).data.id)
+  }
+
+  @Test
+  fun listEventsShouldReturnOrganizationDomainVerifiedEvent() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      "/events",
+      """{
+        "object": "list",
+        "data": [
+          {
+            "object": "event",
+            "id": "event_01H2GNQD5D7ZE06FDDS75NFPHY",
+            "event": "organization_domain.verified",
+            "data": {
+              "object": "organization_domain",
+              "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8",
+              "domain": "example.com",
+              "state": "verified",
+              "verification_strategy": "dns",
+              "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
+            },
+            "created_at": "2023-06-09T18:12:01.837Z"
+          }
+        ],
+        "list_metadata": {
+          "after": null
+        }
+      }"""
+    )
+
+    val eventList = workos.events.listEvents()
+    assertEquals(1, eventList.data.size)
+    val event = eventList.data[0]
+    assertIs<OrganizationDomainEvent>(event)
+    assertEquals("organization_domain.verified", event.event)
+    val domainEvent = event as OrganizationDomainEvent
+    assertEquals("org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8", domainEvent.data.id)
+    assertEquals("example.com", domainEvent.data.domain)
+    assertEquals("rqURsMUCuiaSggGyed8ZAnMk", domainEvent.data.verificationToken)
+  }
+
+  @Test
+  fun listEventsShouldReturnOrganizationDomainVerificationFailedEvent() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      "/events",
+      """{
+        "object": "list",
+        "data": [
+          {
+            "object": "event",
+            "id": "event_01H2GNQD5D7ZE06FDDS75NFPHY",
+            "event": "organization_domain.verification_failed",
+            "data": {
+              "object": "organization_domain",
+              "id": "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8",
+              "domain": "example.com",
+              "state": "failed",
+              "verification_strategy": "dns",
+              "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
+            },
+            "created_at": "2023-06-09T18:12:01.837Z"
+          }
+        ],
+        "list_metadata": {
+          "after": null
+        }
+      }"""
+    )
+
+    val eventList = workos.events.listEvents()
+    assertEquals(1, eventList.data.size)
+    val event = eventList.data[0]
+    assertIs<OrganizationDomainEvent>(event)
+    assertEquals("organization_domain.verification_failed", event.event)
+    val domainEvent = event as OrganizationDomainEvent
+    assertEquals("org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8", domainEvent.data.id)
+    assertEquals("example.com", domainEvent.data.domain)
   }
 }

--- a/src/test/kotlin/com/workos/test/webhooks/OrganizationDomainWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/OrganizationDomainWebhookTests.kt
@@ -1,0 +1,120 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EventType
+import com.workos.webhooks.models.OrganizationDomainEvent
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class OrganizationDomainWebhookTests : TestBase() {
+
+  private val organizationDomainId = "org_domain_01EHT88Z8WZEFWYPM6EC9BX2R8"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType, state: String = "verified"): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "object": "organization_domain",
+        "id": "$organizationDomainId",
+        "domain": "example.com",
+        "state": "$state",
+        "verification_strategy": "dns",
+        "verification_token": "rqURsMUCuiaSggGyed8ZAnMk"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructOrganizationDomainCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationDomainCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationDomainEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationDomainEvent).data.id, organizationDomainId)
+    assertEquals(webhook.data.domain, "example.com")
+  }
+
+  @Test
+  fun constructOrganizationDomainUpdatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationDomainUpdated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationDomainEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationDomainEvent).data.id, organizationDomainId)
+  }
+
+  @Test
+  fun constructOrganizationDomainDeletedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationDomainDeleted)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationDomainEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationDomainEvent).data.id, organizationDomainId)
+  }
+
+  @Test
+  fun constructOrganizationDomainVerifiedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationDomainVerified)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationDomainEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationDomainEvent).data.id, organizationDomainId)
+    assertEquals(webhook.data.domain, "example.com")
+    assertEquals(webhook.data.verificationToken, "rqURsMUCuiaSggGyed8ZAnMk")
+  }
+
+  @Test
+  fun constructOrganizationDomainVerificationFailedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.OrganizationDomainVerificationFailed, "failed")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is OrganizationDomainEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as OrganizationDomainEvent).data.id, organizationDomainId)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds support for `organization_domain.*` webhook events (`created`, `updated`, `deleted`, `verified`, `verification_failed`) which were completely missing from the webhooks module
- Previously, receiving any `organization_domain.*` webhook would crash with a `NullPointerException` because the event type couldn't be deserialized
- Adds `OrganizationDomainEvent` webhook model, `EventType` enum values, and `WebhookJsonDeserializer` cases
- Adds test coverage for both the webhook path (5 tests) and the Events API path (2 tests)

## Test plan

- [x] All 5 webhook event types deserialize correctly via `constructEvent`
- [x] Events API correctly deserializes `organization_domain.verified` and `organization_domain.verification_failed`
- [x] Full existing test suite passes (`./gradlew test` — BUILD SUCCESSFUL)


Made with [Cursor](https://cursor.com)