### PR TITLE
fix: use explicit JsonCreator.Mode.PROPERTIES for Jackson 2.21.0 compatibility

### DIFF
--- a/src/main/kotlin/com/workos/auditlogs/models/AuditLogExport.kt
+++ b/src/main/kotlin/com/workos/auditlogs/models/AuditLogExport.kt
@@ -18,7 +18,7 @@ import java.util.Date
  * @param updatedAt The timestamp of when the AuditLogExport was updated.
  */
 data class AuditLogExport
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "audit_log_export",

--- a/src/main/kotlin/com/workos/common/http/BadRequestExceptionResponse.kt
+++ b/src/main/kotlin/com/workos/common/http/BadRequestExceptionResponse.kt
@@ -3,7 +3,7 @@ package com.workos.common.http
 import com.fasterxml.jackson.annotation.JsonCreator
 
 internal data class BadRequestExceptionResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val message: String? = null,
 
   val code: String? = null,

--- a/src/main/kotlin/com/workos/common/http/EntityError.kt
+++ b/src/main/kotlin/com/workos/common/http/EntityError.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * @param code The error code associated with the field.
  */
 data class EntityError
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val field: String? = null,
 
   val code: String? = null

--- a/src/main/kotlin/com/workos/common/http/GenericErrorResponse.kt
+++ b/src/main/kotlin/com/workos/common/http/GenericErrorResponse.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 internal data class GenericErrorResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val error: String? = null,
 
   @JsonProperty("error_description")

--- a/src/main/kotlin/com/workos/common/http/OAuthErrorResponse.kt
+++ b/src/main/kotlin/com/workos/common/http/OAuthErrorResponse.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * These endpoints return errors in the OAuth 2.0 standard format.
  */
 internal data class OAuthErrorResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("error")
   val error: String? = null,
 

--- a/src/main/kotlin/com/workos/common/http/UnprocessableEntityExceptionResponse.kt
+++ b/src/main/kotlin/com/workos/common/http/UnprocessableEntityExceptionResponse.kt
@@ -3,7 +3,7 @@ package com.workos.common.http
 import com.fasterxml.jackson.annotation.JsonCreator
 
 internal data class UnprocessableEntityExceptionResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val message: String?,
   val code: String?,
   val errors: List<EntityError> = emptyList()

--- a/src/main/kotlin/com/workos/common/models/ListMetadata.kt
+++ b/src/main/kotlin/com/workos/common/models/ListMetadata.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * @param before The `before` cursor to use for retrieving the previous page of data.
  */
 data class ListMetadata
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val after: String?,
 

--- a/src/main/kotlin/com/workos/common/models/Role.kt
+++ b/src/main/kotlin/com/workos/common/models/Role.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  *
  * @param slug The unique role identifier.
  */
-data class Role @JsonCreator constructor(
+data class Role @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("slug")
   val slug: String
 )

--- a/src/main/kotlin/com/workos/directorysync/models/Directory.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/Directory.kt
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param updatedAt The timestamp of when the Directory was updated.
  */
 data class Directory
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "directory",

--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryGroupList.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryGroupList.kt
@@ -12,7 +12,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class DirectoryGroupList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val data: List<Group>,
 

--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryList.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryList.kt
@@ -12,7 +12,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class DirectoryList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val data: List<Directory>,
 

--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryUserList.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryUserList.kt
@@ -12,7 +12,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class DirectoryUserList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   var data: List<User>,
 

--- a/src/main/kotlin/com/workos/directorysync/models/Email.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/Email.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * @param value The email address.
  */
 data class Email
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val primary: Boolean?,
 

--- a/src/main/kotlin/com/workos/directorysync/models/Group.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/Group.kt
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param rawAttributes An object containing the data returned from the Directory Provider.
  */
 open class Group
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   open val obj: String = "directory_group",

--- a/src/main/kotlin/com/workos/directorysync/models/User.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/User.kt
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param rawAttributes An object containing the data returned from the Directory Provider.
  */
 open class User
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   open val obj: String = "directory_user",

--- a/src/main/kotlin/com/workos/events/models/Event.kt
+++ b/src/main/kotlin/com/workos/events/models/Event.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
  */
 @JsonDeserialize(using = EventsJsonDeserializer::class)
 abstract class Event
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   open val id: String,
 

--- a/src/main/kotlin/com/workos/events/models/EventList.kt
+++ b/src/main/kotlin/com/workos/events/models/EventList.kt
@@ -8,7 +8,7 @@ import com.workos.common.models.ListMetadata
  * A list of WorkOS [Event] resources.
  */
 data class EventList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "list",

--- a/src/main/kotlin/com/workos/events/models/EventTypes.kt
+++ b/src/main/kotlin/com/workos/events/models/EventTypes.kt
@@ -21,7 +21,7 @@ import com.workos.usermanagement.models.User as UmUser
  */
 
 data class OrganizationEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -30,7 +30,7 @@ data class OrganizationEvent
 ) : Event(id, event, createdAt, context)
 
 data class ConnectionEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -38,7 +38,7 @@ data class ConnectionEvent
   val data: Connection
 ) : Event(id, event, createdAt, context)
 data class DirectoryUserEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -47,7 +47,7 @@ data class DirectoryUserEvent
 ) : Event(id, event, createdAt, context)
 
 data class DirectoryGroupEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -56,7 +56,7 @@ data class DirectoryGroupEvent
 ) : Event(id, event, createdAt, context)
 
 data class DirectoryEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -65,7 +65,7 @@ data class DirectoryEvent
 ) : Event(id, event, createdAt, context)
 
 data class UserEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -74,7 +74,7 @@ data class UserEvent
 ) : Event(id, event, createdAt, context)
 
 data class AuthenticationEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -83,7 +83,7 @@ data class AuthenticationEvent
 ) : Event(id, event, createdAt, context)
 
 data class EmailVerificationEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -92,7 +92,7 @@ data class EmailVerificationEvent
 ) : Event(id, event, createdAt, context)
 
 data class MagicAuthEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -101,7 +101,7 @@ data class MagicAuthEvent
 ) : Event(id, event, createdAt, context)
 
 data class InvitationEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -110,7 +110,7 @@ data class InvitationEvent
 ) : Event(id, event, createdAt, context)
 
 data class PasswordResetEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -119,7 +119,7 @@ data class PasswordResetEvent
 ) : Event(id, event, createdAt, context)
 
 data class OrganizationDomainEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -128,7 +128,7 @@ data class OrganizationDomainEvent
 ) : Event(id, event, createdAt, context)
 
 data class RoleEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -137,7 +137,7 @@ data class RoleEvent
 ) : Event(id, event, createdAt, context)
 
 data class OrganizationMembershipEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -146,7 +146,7 @@ data class OrganizationMembershipEvent
 ) : Event(id, event, createdAt, context)
 
 data class EventDirectoryUser
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id") val id: String,
   @JsonProperty("directory_id") val directoryId: String,
   @JsonProperty("organization_id") val organizationId: String?,
@@ -163,37 +163,37 @@ data class EventDirectoryUser
 )
 
 data class OrganizationEventData
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val id: String,
   val name: String
 )
 
 data class DirectoryEventData
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val id: String,
   val name: String
 )
 
 data class DirectoryGroupEventData
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val id: String,
   val name: String
 )
 
 data class DirectoryUserMinimal
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val id: String,
   val email: String?
 )
 
 data class SessionImpersonator
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val email: String?,
   val reason: String?
 )
 
 data class SessionEventData
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val obj: String = "session",
   val id: String,
   @JsonProperty("user_id") val userId: String?,
@@ -206,7 +206,7 @@ data class SessionEventData
 )
 
 data class SessionEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -215,13 +215,13 @@ data class SessionEvent
 ) : Event(id, event, createdAt, context)
 
 data class DirectoryGroupMembershipData
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val user: EventDirectoryUser,
   val group: Group
 )
 
 data class DirectoryGroupMembershipEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,
@@ -230,7 +230,7 @@ data class DirectoryGroupMembershipEvent
 ) : Event(id, event, createdAt, context)
 
 data class UnknownEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   override val id: String,
   override val event: String,
   override val createdAt: String,

--- a/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
@@ -7,7 +7,7 @@ import com.workos.fga.CHECK_RESULT_AUTHORIZED
 import com.workos.fga.types.WarrantCheckOptions
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class CheckResponse @JsonCreator constructor(
+data class CheckResponse @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("result")
   val result: String,
 
@@ -25,7 +25,7 @@ data class CheckResponse @JsonCreator constructor(
   }
 }
 
-data class DebugInfo @JsonCreator constructor(
+data class DebugInfo @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("processing_time")
   val processingTime: Int,
 
@@ -33,7 +33,7 @@ data class DebugInfo @JsonCreator constructor(
   val decisionTree: DecisionTreeNode
 )
 
-data class DecisionTreeNode @JsonCreator constructor(
+data class DecisionTreeNode @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("check")
   val check: WarrantCheckOptions,
 

--- a/src/main/kotlin/com/workos/fga/models/QueryResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/QueryResponse.kt
@@ -6,7 +6,7 @@ import com.workos.common.models.ListMetadata
 import com.workos.fga.types.QueryResult
 
 data class QueryResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<QueryResult>,
 

--- a/src/main/kotlin/com/workos/fga/models/Resource.kt
+++ b/src/main/kotlin/com/workos/fga/models/Resource.kt
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param resourceId The unique ID of the resource.
  * @param meta A JSON object containing additional information about the resource.
  */
-data class Resource @JsonCreator constructor(
+data class Resource @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("resource_type")
   val resourceType: String,
 

--- a/src/main/kotlin/com/workos/fga/models/Resources.kt
+++ b/src/main/kotlin/com/workos/fga/models/Resources.kt
@@ -11,7 +11,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class Resources
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<Resource>,
 

--- a/src/main/kotlin/com/workos/fga/models/Subject.kt
+++ b/src/main/kotlin/com/workos/fga/models/Subject.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param relation Specifies a relation required on the resource to be part of the subject group.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class Subject @JsonCreator constructor(
+data class Subject @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("resource_type")
   val resourceType: String,
 

--- a/src/main/kotlin/com/workos/fga/models/Warning.kt
+++ b/src/main/kotlin/com/workos/fga/models/Warning.kt
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 @JsonSubTypes(
   JsonSubTypes.Type(value = MissingContextKeysWarning::class, name = "missing_context_keys")
 )
-open class Warning @JsonCreator constructor(
+open class Warning @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("code")
   open val code: String,
 
@@ -24,7 +24,7 @@ open class Warning @JsonCreator constructor(
 )
 
 @JsonTypeName("missing_context_keys")
-data class MissingContextKeysWarning @JsonCreator constructor(
+data class MissingContextKeysWarning @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("code")
   override val code: String,
 

--- a/src/main/kotlin/com/workos/fga/models/Warrant.kt
+++ b/src/main/kotlin/com/workos/fga/models/Warrant.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param subject (see [Subject]) The resource with the specified `relation` to the resource provided by resourceType and resourceId.
  * @param policy A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
  */
-data class Warrant @JsonCreator constructor(
+data class Warrant @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("resource_type")
   val resourceType: String,
 

--- a/src/main/kotlin/com/workos/fga/models/Warrants.kt
+++ b/src/main/kotlin/com/workos/fga/models/Warrants.kt
@@ -11,7 +11,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class Warrants
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<Warrant>,
 

--- a/src/main/kotlin/com/workos/fga/models/WriteWarrantResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/WriteWarrantResponse.kt
@@ -3,7 +3,7 @@ package com.workos.fga.models
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class WriteWarrantResponse @JsonCreator constructor(
+data class WriteWarrantResponse @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("warrant_token")
   val warrantToken: String
 )

--- a/src/main/kotlin/com/workos/mfa/models/Challenge.kt
+++ b/src/main/kotlin/com/workos/mfa/models/Challenge.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * Represents a [Challenge] and its json properties.
  */
 data class Challenge
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "authentication_challenge",

--- a/src/main/kotlin/com/workos/mfa/models/Factor.kt
+++ b/src/main/kotlin/com/workos/mfa/models/Factor.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * Represents a [Factor] and its json properties.
  */
 data class Factor
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "authentication_factor",

--- a/src/main/kotlin/com/workos/mfa/models/Sms.kt
+++ b/src/main/kotlin/com/workos/mfa/models/Sms.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * Represents a [Factor] and its json properties.
  */
 data class Sms
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("phone_number")
   val phoneNumber: String

--- a/src/main/kotlin/com/workos/mfa/models/Totp.kt
+++ b/src/main/kotlin/com/workos/mfa/models/Totp.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * Represents [Totp] and its json properties.
  */
 data class Totp
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
 
   @JvmField
   @JsonProperty("issuer")

--- a/src/main/kotlin/com/workos/mfa/models/VerifyChallengeResponse.kt
+++ b/src/main/kotlin/com/workos/mfa/models/VerifyChallengeResponse.kt
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * Represents a [VerifyChallengeResponse] in both successfull and error responses.
  */
 data class VerifyChallengeResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("challenge")
   val challenge: Challenge,

--- a/src/main/kotlin/com/workos/mfa/models/VerifyFactorResponse.kt
+++ b/src/main/kotlin/com/workos/mfa/models/VerifyFactorResponse.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @Deprecated("Please use `verifyChallenge` instead")
 data class VerifyFactorResponse
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("challenge")
   val challenge: Challenge,

--- a/src/main/kotlin/com/workos/organizations/models/Organization.kt
+++ b/src/main/kotlin/com/workos/organizations/models/Organization.kt
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param updatedAt The timestamp of when the Organization was updated.
  */
 data class Organization
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "organization",

--- a/src/main/kotlin/com/workos/organizations/models/OrganizationDomain.kt
+++ b/src/main/kotlin/com/workos/organizations/models/OrganizationDomain.kt
@@ -16,7 +16,7 @@ import com.workos.organizations.types.OrganizationDomainVerificationStrategy
  * @param domain Domain for the Organization Domain.
  */
 data class OrganizationDomain
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "organization_domain",

--- a/src/main/kotlin/com/workos/organizations/models/OrganizationList.kt
+++ b/src/main/kotlin/com/workos/organizations/models/OrganizationList.kt
@@ -12,7 +12,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class OrganizationList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val data: List<Organization>,
 

--- a/src/main/kotlin/com/workos/passwordless/models/PasswordlessSession.kt
+++ b/src/main/kotlin/com/workos/passwordless/models/PasswordlessSession.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param expiresAt The ISO-8601 datetime at which the session expires.
  * @param link The link for the user to authenticate with. You can use this link to send a custom email to the user, or send an email using Email a Magic Link to the user. Once a user has authenticated with the link, WorkOS issues a redirect to the Environment's default redirect URI, with a `code` parameter and, if provided during session creation, a `state` parameter. `code` can then be exchanged for an access token and user Profile. To perform this exchange, the Developer should make a `POST` request to the `/sso/token` endpoint.
  */
-data class PasswordlessSession @JsonCreator constructor(
+data class PasswordlessSession @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String? = "passwordless_session",

--- a/src/main/kotlin/com/workos/passwordless/models/SendSessionResponse.kt
+++ b/src/main/kotlin/com/workos/passwordless/models/SendSessionResponse.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  *
  * @param success Whether or not the passwordless session was sent successfully.
  */
-data class SendSessionResponse @JsonCreator constructor(
+data class SendSessionResponse @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val success: Boolean
 )

--- a/src/main/kotlin/com/workos/portal/models/Link.kt
+++ b/src/main/kotlin/com/workos/portal/models/Link.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * @param link The generated URL for access to the Admin Portal.
  */
 data class Link
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val link: String
 )

--- a/src/main/kotlin/com/workos/roles/models/Role.kt
+++ b/src/main/kotlin/com/workos/roles/models/Role.kt
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param updatedAt The timestamp of when the Role was updated.
  */
 data class Role
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "role",

--- a/src/main/kotlin/com/workos/roles/models/RoleList.kt
+++ b/src/main/kotlin/com/workos/roles/models/RoleList.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * @param data A list of [Role].
  */
 data class RoleList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val data: List<Role>,
 )

--- a/src/main/kotlin/com/workos/sso/models/Connection.kt
+++ b/src/main/kotlin/com/workos/sso/models/Connection.kt
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param updatedAt The timestamp of when the Connection was updated.
  */
 data class Connection
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "connection",

--- a/src/main/kotlin/com/workos/sso/models/ConnectionDomain.kt
+++ b/src/main/kotlin/com/workos/sso/models/ConnectionDomain.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param id Unique identifier for a Connection Domain.
  */
 data class ConnectionDomain
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "connection_domain",

--- a/src/main/kotlin/com/workos/sso/models/ConnectionList.kt
+++ b/src/main/kotlin/com/workos/sso/models/ConnectionList.kt
@@ -12,7 +12,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class ConnectionList
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val data: List<Connection>,
 

--- a/src/main/kotlin/com/workos/sso/models/Profile.kt
+++ b/src/main/kotlin/com/workos/sso/models/Profile.kt
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param rawAttributes Object of key-value pairs containing relevant user data from the Identity Provider.
  */
 data class Profile
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   val obj: String = "profile",

--- a/src/main/kotlin/com/workos/sso/models/ProfileAndToken.kt
+++ b/src/main/kotlin/com/workos/sso/models/ProfileAndToken.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param token An access token that can be used to manage sessions like one would a normal OAuth access token. Access tokens are one-time use and expire 10 minutes after they’re created. Session duration is up to the Developer.
  */
 data class ProfileAndToken
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val profile: Profile,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/Authentication.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Authentication.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param impersonator An impersonation definition.
  * @param oauthTokens OAuth tokens from third-party providers.
  */
-data class Authentication @JsonCreator constructor(
+data class Authentication @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("user")
   val user: User? = null,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationChallenge.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationChallenge.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param expiresAt The timestamp when the challenge will expire.
  * @param authenticationFactorId The unique ID of the authentication factor the challenge belongs to.
  */
-data class AuthenticationChallenge @JsonCreator constructor(
+data class AuthenticationChallenge @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventData.kt
@@ -16,7 +16,7 @@ import com.workos.usermanagement.types.AuthenticationEventTypeEnumType
  * @param userAgent The user agent of the authentication attempy, if available.
  * @param error Error details if the event is for a failed authentication attempt.
  */
-data class AuthenticationEventData @JsonCreator constructor(
+data class AuthenticationEventData @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("type")
   val type: AuthenticationEventTypeEnumType,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventError.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventError.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param code The error code.
  * @param message The error message.
  */
-data class AuthenticationEventError @JsonCreator constructor(
+data class AuthenticationEventError @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("code")
   val issuer: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationFactor.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationFactor.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param totp Time-based one-time password (see [AuthenticationTotp]).
  * @param userId The ID of the user.
  */
-data class AuthenticationFactor @JsonCreator constructor(
+data class AuthenticationFactor @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationFactors.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationFactors.kt
@@ -11,7 +11,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class AuthenticationFactors
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<AuthenticationFactor>,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationImpersonator.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationImpersonator.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param email The email address of the WorkOS Dashboard user who is impersonating the user.
  * @param reason The justification the impersonator gave for impersonating the user.
  */
-data class AuthenticationImpersonator @JsonCreator constructor(
+data class AuthenticationImpersonator @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("email")
   val email: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationTotp.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationTotp.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param secret TOTP secret that can be manually entered into some authenticator apps in place of scanning a QR code.
  * @param uri The `otpauth` URI that is encoded by the provided `qr_code`.
  */
-data class AuthenticationTotp @JsonCreator constructor(
+data class AuthenticationTotp @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("issuer")
   val issuer: String? = null,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/EmailVerification.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/EmailVerification.kt
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param createdAt The timestamp when the email verification code was created.
  * @param updatedAt The timestamp when the email verification code was last updated.
  */
-data class EmailVerification @JsonCreator constructor(
+data class EmailVerification @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/EmailVerificationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/EmailVerificationEventData.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param createdAt The timestamp when the email verification code was created.
  * @param updatedAt The timestamp when the email verification code was last updated.
  */
-data class EmailVerificationEventData @JsonCreator constructor(
+data class EmailVerificationEventData @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/EnrolledAuthenticationFactor.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/EnrolledAuthenticationFactor.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param challenge The [AuthenticationChallenge] that is used to complete the authentication process.
  * @param factor The [AuthenticationFactor] that represents the additional authentication method used on top of the existing authentication strategy.
  */
-data class EnrolledAuthenticationFactor @JsonCreator constructor(
+data class EnrolledAuthenticationFactor @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("challenge")
   val challenge: AuthenticationChallenge,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/Identity.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Identity.kt
@@ -11,7 +11,7 @@ import com.workos.usermanagement.types.IdentityProviderEnumType
  * @param type The email address of the user.
  * @param provider The state of the invitation (see enum values in [IdentityProviderEnumType]).
  */
-data class Identity @JsonCreator constructor(
+data class Identity @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("idp_id")
   val idpId: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/Invitation.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Invitation.kt
@@ -22,7 +22,7 @@ import com.workos.usermanagement.types.InvitationStateEnumType
  * @param createdAt The timestamp when the invitation was created.
  * @param updatedAt The timestamp when the invitation was last updated.
  */
-data class Invitation @JsonCreator constructor(
+data class Invitation @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/InvitationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/InvitationEventData.kt
@@ -20,7 +20,7 @@ import com.workos.usermanagement.types.InvitationStateEnumType
  * @param createdAt The timestamp when the invitation was created.
  * @param updatedAt The timestamp when the invitation was last updated.
  */
-data class InvitationEventData @JsonCreator constructor(
+data class InvitationEventData @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/Invitations.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Invitations.kt
@@ -11,7 +11,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class Invitations
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<Invitation>,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/MagicAuth.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/MagicAuth.kt
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param createdAt The timestamp when the Magic Auth code was created.
  * @param updatedAt The timestamp when the Magic Auth code was last updated.
  */
-data class MagicAuth @JsonCreator constructor(
+data class MagicAuth @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/MagicAuthEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/MagicAuthEventData.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param createdAt The timestamp when the Magic Auth code was created.
  * @param updatedAt The timestamp when the Magic Auth code was last updated.
  */
-data class MagicAuthEventData @JsonCreator constructor(
+data class MagicAuthEventData @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/OAuthTokens.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OAuthTokens.kt
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param expiresAt The timestamp when the access token expires.
  * @param scopes The scopes granted to the access token.
  */
-data class OAuthTokens @JsonCreator constructor(
+data class OAuthTokens @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("access_token")
   val accessToken: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
@@ -19,7 +19,7 @@ import com.workos.usermanagement.types.OrganizationMembershipStatusEnumType
  * @param customAttributes Custom attributes from the identity provider.
  * @param directoryManaged Whether the organization membership is managed by a directory sync connection.
  */
-data class OrganizationMembership @JsonCreator constructor(
+data class OrganizationMembership @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/OrganizationMemberships.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OrganizationMemberships.kt
@@ -11,7 +11,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class OrganizationMemberships
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<OrganizationMembership>,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/PasswordReset.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/PasswordReset.kt
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param expiresAt The timestamp when the password reset token will expire.
  * @param createdAt The timestamp when the password reset token was created.
  */
-data class PasswordReset @JsonCreator constructor(
+data class PasswordReset @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/PasswordResetEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/PasswordResetEventData.kt
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param expiresAt The timestamp when the password reset token will expire.
  * @param createdAt The timestamp when the password reset token was created.
  */
-data class PasswordResetEventData @JsonCreator constructor(
+data class PasswordResetEventData @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/RefreshAuthentication.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/RefreshAuthentication.kt
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param accessToken A JWT containing information about the session.
  * @param refreshToken Exchange this token for a new access token.
  */
-data class RefreshAuthentication @JsonCreator constructor(
+data class RefreshAuthentication @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("access_token")
   val accessToken: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/User.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/User.kt
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param createdAt The timestamp when the user was created.
  * @param updatedAt The timestamp when the user was last updated.
  */
-data class User @JsonCreator constructor(
+data class User @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/Users.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Users.kt
@@ -11,7 +11,7 @@ import com.workos.common.models.ListMetadata
  * @param listMetadata [com.workos.common.models.ListMetadata].
  */
 data class Users
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("data")
   val data: List<User>,
 

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionActivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionActivatedEvent.kt
@@ -7,7 +7,7 @@ import com.workos.sso.models.Connection
  * Webhook Event for `connection.activated`.
  */
 class ConnectionActivatedEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionDeactivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionDeactivatedEvent.kt
@@ -7,7 +7,7 @@ import com.workos.sso.models.Connection
  * Webhook Event for `connection.deactivated`.
  */
 class ConnectionDeactivatedEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionDeletedEvent.kt
@@ -6,7 +6,7 @@ import com.workos.sso.models.Connection
 /**
  * Webhook Event for `connection.deleted`.
  */
-class ConnectionDeletedEvent @JsonCreator constructor(
+class ConnectionDeletedEvent @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryActivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryActivatedEvent.kt
@@ -6,7 +6,7 @@ import com.workos.directorysync.models.Directory
 /**
  * Webhook Event for `dsync.activated`.
  */
-class DirectoryActivatedEvent @JsonCreator constructor(
+class DirectoryActivatedEvent @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryDeactivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryDeactivatedEvent.kt
@@ -6,7 +6,7 @@ import com.workos.directorysync.models.Directory
 /**
  * Webhook Event for `dsync.deactivated`.
  */
-class DirectoryDeactivatedEvent @JsonCreator constructor(
+class DirectoryDeactivatedEvent @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryDeletedEvent.kt
@@ -6,7 +6,7 @@ import com.workos.directorysync.models.Directory
 /**
  * Webhook Event for `dsync.deleted`.
  */
-class DirectoryDeletedEvent @JsonCreator constructor(
+class DirectoryDeletedEvent @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupDeletedEvent.kt
@@ -6,7 +6,7 @@ import com.workos.directorysync.models.Group
 /**
  * Webhook Event for `dsync.group.deleted`.
  */
-class DirectoryGroupDeletedEvent @JsonCreator constructor(
+class DirectoryGroupDeletedEvent @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUpdatedEvent.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * Webhook Event for `dsync.group.updated`.
  */
 class DirectoryGroupUpdatedEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserAddedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserAddedEvent.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 /**
  * Webhook Event for `dsync.group.user_added`.
  */
-class DirectoryGroupUserAddedEvent @JsonCreator constructor(
+class DirectoryGroupUserAddedEvent @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   override val id: String,
 

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserEvent.kt
@@ -14,7 +14,7 @@ import com.workos.directorysync.models.User
  * @param user The modified [com.workos.directorysync.models.User].
  */
 data class DirectoryGroupUserEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("directory_id")
   val directoryId: String,

--- a/src/main/kotlin/com/workos/webhooks/models/GroupUpdated.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/GroupUpdated.kt
@@ -8,7 +8,7 @@ import com.workos.directorysync.models.Group
  * @suppress
  */
 class GroupUpdated
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   override val obj: String = "directory_group",

--- a/src/main/kotlin/com/workos/webhooks/models/UserUpdated.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/UserUpdated.kt
@@ -11,7 +11,7 @@ import com.workos.directorysync.models.UserState
  * @suppress
  */
 open class UserUpdated
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   @JsonProperty("object")
   override val obj: String = "directory_user",

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
  */
 @JsonDeserialize(using = WebhookJsonDeserializer::class)
 abstract class WebhookEvent
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   open val id: String,
 

--- a/src/main/kotlin/com/workos/widgets/models/WidgetToken.kt
+++ b/src/main/kotlin/com/workos/widgets/models/WidgetToken.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
  * @param token The generated widget token.
  */
 data class WidgetToken
-@JsonCreator constructor(
+@JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JvmField
   val token: String
 )


### PR DESCRIPTION
Jackson 2.21.0 is stricter about `@JsonCreator(mode=DEFAULT)` and throws `InvalidDefinitionException` when Kotlin data classes with all-optional parameters generate both no-arg and parameterized constructors. Explicitly setting `Mode.PROPERTIES` resolves the ambiguity.

Fixes #305
