### PR TITLE
feat: Add `user` to organization membership response

### DIFF
--- a/src/main/kotlin/com/workos/authorization/models/SlimOrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/authorization/models/SlimOrganizationMembership.kt
@@ -2,6 +2,7 @@ package com.workos.authorization.models
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.usermanagement.models.User
 import com.workos.usermanagement.types.OrganizationMembershipStatusEnumType
 
 /**
@@ -10,6 +11,11 @@ import com.workos.usermanagement.types.OrganizationMembershipStatusEnumType
  * Unlike the full [com.workos.usermanagement.models.OrganizationMembership],
  * this model omits role, custom_attributes, and other fields not returned
  * by the authorization endpoints.
+ *
+ * The [user] field is only populated by endpoints that explicitly include
+ * the full user object in their response (currently
+ * `GET /authorization/resources/:resource_id/organization_memberships` and
+ * `GET /authorization/organizations/:organization_id/resources/:resource_type_slug/:external_id/organization_memberships`).
  */
 data class SlimOrganizationMembership
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
@@ -43,5 +49,9 @@ data class SlimOrganizationMembership
 
   @JvmField
   @JsonProperty("updated_at")
-  val updatedAt: String
+  val updatedAt: String,
+
+  @JvmField
+  @JsonProperty("user")
+  val user: User? = null
 )

--- a/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
@@ -18,6 +18,9 @@ import com.workos.usermanagement.types.OrganizationMembershipStatusEnumType
  * @param updatedAt The timestamp when the user was last updated.
  * @param customAttributes Custom attributes from the identity provider.
  * @param directoryManaged Whether the organization membership is managed by a directory sync connection.
+ * @param user The [User] associated with this organization membership.
+ *   Always populated by API responses, but may be `null` when the membership
+ *   is delivered via an `organization_membership.*` webhook event.
  */
 data class OrganizationMembership @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
@@ -48,5 +51,8 @@ data class OrganizationMembership @JsonCreator(mode = JsonCreator.Mode.PROPERTIE
   val customAttributes: Map<String, Any> = emptyMap(),
 
   @JsonProperty("directory_managed")
-  val directoryManaged: Boolean = false
+  val directoryManaged: Boolean = false,
+
+  @JsonProperty("user")
+  val user: User? = null
 )

--- a/src/test/kotlin/com/workos/test/authorization/AuthorizationApiTest.kt
+++ b/src/test/kotlin/com/workos/test/authorization/AuthorizationApiTest.kt
@@ -438,7 +438,18 @@ class AuthorizationApiTest : TestBase() {
             "status": "active",
             "directory_managed": false,
             "created_at": "2026-01-15T12:00:00.000Z",
-            "updated_at": "2026-01-15T12:00:00.000Z"
+            "updated_at": "2026-01-15T12:00:00.000Z",
+            "user": {
+              "id": "user_01EHQTV6MWP9P1F4ZXGXMC8ABB",
+              "email": "marcelina@example.com",
+              "first_name": "Marcelina",
+              "last_name": "Davis",
+              "email_verified": true,
+              "profile_picture_url": "https://example.com/avatar.png",
+              "last_sign_in_at": "2026-01-15T12:00:00.000Z",
+              "created_at": "2026-01-15T12:00:00.000Z",
+              "updated_at": "2026-01-15T12:00:00.000Z"
+            }
           }
         ],
         "list_metadata": {
@@ -457,6 +468,11 @@ class AuthorizationApiTest : TestBase() {
     assertEquals("om_01HXYZ", result.data[0].id)
     assertEquals("user_01EHQTV6MWP9P1F4ZXGXMC8ABB", result.data[0].userId)
     assertEquals("active", result.data[0].status.type)
+    assertEquals("user_01EHQTV6MWP9P1F4ZXGXMC8ABB", result.data[0].user?.id)
+    assertEquals("marcelina@example.com", result.data[0].user?.email)
+    assertEquals("Marcelina", result.data[0].user?.firstName)
+    assertEquals("Davis", result.data[0].user?.lastName)
+    assertEquals(true, result.data[0].user?.emailVerified)
   }
 
   @Test
@@ -473,7 +489,16 @@ class AuthorizationApiTest : TestBase() {
             "status": "active",
             "directory_managed": false,
             "created_at": "2026-01-15T12:00:00.000Z",
-            "updated_at": "2026-01-15T12:00:00.000Z"
+            "updated_at": "2026-01-15T12:00:00.000Z",
+            "user": {
+              "id": "user_01ABC",
+              "email": "marcelina@example.com",
+              "first_name": "Marcelina",
+              "last_name": "Davis",
+              "email_verified": true,
+              "created_at": "2026-01-15T12:00:00.000Z",
+              "updated_at": "2026-01-15T12:00:00.000Z"
+            }
           }
         ],
         "list_metadata": {
@@ -490,6 +515,8 @@ class AuthorizationApiTest : TestBase() {
 
     assertEquals(1, result.data.size)
     assertEquals("om_01HXYZ", result.data[0].id)
+    assertEquals("user_01ABC", result.data[0].user?.id)
+    assertEquals("marcelina@example.com", result.data[0].user?.email)
   }
 
   // ── Permissions ────────────────────────────────────────────────────────

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -1190,7 +1190,18 @@ class UserManagementApiTest : TestBase() {
         "status": "active",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z",
-        "directory_managed": false
+        "directory_managed": false,
+        "user": {
+          "id": "user_456",
+          "email": "marcelina@example.com",
+          "first_name": "Marcelina",
+          "last_name": "Davis",
+          "email_verified": true,
+          "profile_picture_url": "https://example.com/avatar.png",
+          "last_sign_in_at": "2021-06-25T19:07:33.155Z",
+          "created_at": "2021-06-25T19:07:33.155Z",
+          "updated_at": "2021-06-25T19:07:33.155Z"
+        }
       }"""
     )
 
@@ -1198,14 +1209,25 @@ class UserManagementApiTest : TestBase() {
 
     assertEquals(
       OrganizationMembership(
-        "om_123",
-        "user_456",
-        "org_789",
-        OrganizationMembershipRole("admin"),
-        listOf(OrganizationMembershipRole("admin")),
-        OrganizationMembershipStatusEnumType.Active,
-        "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z",
+        id = "om_123",
+        userId = "user_456",
+        organizationId = "org_789",
+        role = OrganizationMembershipRole("admin"),
+        roles = listOf(OrganizationMembershipRole("admin")),
+        status = OrganizationMembershipStatusEnumType.Active,
+        createdAt = "2021-06-25T19:07:33.155Z",
+        updatedAt = "2021-06-25T19:07:33.155Z",
+        user = User(
+          id = "user_456",
+          email = "marcelina@example.com",
+          firstName = "Marcelina",
+          lastName = "Davis",
+          emailVerified = true,
+          profilePictureUrl = "https://example.com/avatar.png",
+          lastSignInAt = "2021-06-25T19:07:33.155Z",
+          createdAt = "2021-06-25T19:07:33.155Z",
+          updatedAt = "2021-06-25T19:07:33.155Z"
+        )
       ),
       organizationMembership
     )


### PR DESCRIPTION
## Description

Adds the `user` object to organization membership models so SDK consumers can access the full `User` payload that the WorkOS API now returns alongside organization memberships.

## Changes
- **Full `OrganizationMembership`** (`com.workos.usermanagement.models.OrganizationMembership`): added a nullable `user: User?` field. The API always returns `user` on full OM responses, but the field is kept nullable because the same type is reused as the data payload for `organization_membership.*` webhook events, which do not include `user`. KDoc was updated to clarify when the field is populated.
- **`SlimOrganizationMembership`** (`com.workos.authorization.models.SlimOrganizationMembership`): added a nullable `user: User?` field. The base/slim shape returned by most Authorization API endpoints does not include `user`, but the following two endpoints now do, so the field is populated when consuming them:
  - `GET /authorization/resources/:resource_id/organization_memberships`
  - `GET /authorization/organizations/:organization_id/resources/:resource_type_slug/:external_id/organization_memberships`

