### PR TITLE
feat: Add external_id to User model

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/models/User.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/User.kt
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param lastSignInAt The timestamp when the user last signed in.
  * @param createdAt The timestamp when the user was created.
  * @param updatedAt The timestamp when the user was last updated.
+ * @param externalId An identifier for the user that is unique within an environment, set by the consumer of the API.
  */
 data class User @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   @JsonProperty("id")
@@ -42,5 +43,8 @@ data class User @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
   val createdAt: String,
 
   @JsonProperty("updated_at")
-  val updatedAt: String
+  val updatedAt: String,
+
+  @JsonProperty("external_id")
+  val externalId: String? = null
 )

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -55,7 +55,8 @@ class UserManagementApiTest : TestBase() {
         "last_name": "User",
         "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
-        "updated_at": "2021-06-25T19:07:33.155Z"
+        "updated_at": "2021-06-25T19:07:33.155Z",
+        "external_id": "external_123"
       }"""
     )
 
@@ -63,15 +64,16 @@ class UserManagementApiTest : TestBase() {
 
     assertEquals(
       User(
-        "user_123",
-        "test01@example.com",
-        "Test",
-        "User",
-        true,
-        "https://example.com/profile_picture.jpg",
-        "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z",
-        "2021-06-25T19:07:33.155Z"
+        id = "user_123",
+        email = "test01@example.com",
+        firstName = "Test",
+        lastName = "User",
+        emailVerified = true,
+        profilePictureUrl = "https://example.com/profile_picture.jpg",
+        lastSignInAt = "2021-06-25T19:07:33.155Z",
+        createdAt = "2021-06-25T19:07:33.155Z",
+        updatedAt = "2021-06-25T19:07:33.155Z",
+        externalId = "external_123"
       ),
       user
     )


### PR DESCRIPTION
## Description

Optional `external_id` was missing from the `User` object. Adding for consistency with our other SDKs.
