### PR TITLE
ci: Stagger Central Portal publish/close to fix release failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,11 @@ jobs:
           myNexusPassword=${MAVEN_PASSWORD}
           EOF
 
-          ./gradlew publishToMyNexus closeAndReleaseMyNexusStagingRepository -Prelease
+          # Upload first, then give Sonatype's Central Portal compatibility
+          # bridge time to register the artifacts before asking it to close
+          # and release the staging repository.
+          ./gradlew publishToMyNexus -Prelease
+
+          sleep 60
+
+          ./gradlew closeAndReleaseMyNexusStagingRepository -Prelease

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.io.FileOutputStream
+import java.time.Duration
 import java.util.Properties
 
 group = "com.workos"
@@ -160,6 +161,16 @@ publishing {
 }
 
 nexusPublishing {
+  // Central Portal compatibility bridge can be slow to register uploaded
+  // artifacts; give the close/release polling room to wait it out.
+  clientTimeout.set(Duration.ofMinutes(10))
+  connectTimeout.set(Duration.ofMinutes(5))
+
+  transitionCheckOptions {
+    maxRetries.set(180)
+    delayBetween.set(Duration.ofSeconds(10))
+  }
+
   repositories {
     create("myNexus") {
       // Central Portal compatibility endpoints (post-OSSRH EOL June 30, 2025)


### PR DESCRIPTION
## Summary

The 4.25.0 release [failed at `:closeMyNexusStagingRepository`](https://github.com/workos/workos-kotlin/actions/runs/25221973124/job/73956172228) with:

> Failed to close staging repository, server at https://ossrh-staging-api.central.sonatype.com/service/local/ responded with status code 400, body: Failed to process request: No objects found in the repository

`publishMavenPublicationToMyNexusRepository` succeeded — artifacts uploaded — but Sonatype's Central Portal OSSRH compatibility bridge had not yet registered the upload by the time `closeMyNexusStagingRepository` fired, so the close API saw an empty staging repo and 400'd. The plugin spent ~5 minutes retrying internally before giving up.

This is a known timing problem with the Central Portal compat bridge. Rather than swap the publishing plugin (which would require bumping Gradle and the Kotlin Gradle plugin past versions compatible with this SDK's current Kotlin runtime, forcing a major version bump), this PR keeps `gradle-nexus-publish-plugin` 2.0.0 and works around the timing:

- Split `publishToMyNexus` and `closeAndReleaseMyNexusStagingRepository` into two separate Gradle invocations with a 60s sleep between them, so uploads have time to register before the close call.
- Bump `clientTimeout` to 10 minutes and `transitionCheckOptions.maxRetries` to 180, so transient bridge slowness during state-transition polling does not abort the release.

No code, dependency, or version changes — pipeline-only fix.

## Test plan

- [ ] Cut a fresh release-please tag and confirm the `Release` workflow's `Publish to Maven` job completes both invocations and the artifact appears at https://central.sonatype.com.
- [ ] If the close still fails, the `sleep 60` can be increased (or the close step retried via re-running the failed job) without re-uploading.

## Notes

If this stops working again on a future release, the more durable fix is to migrate to a plugin with first-class Central Portal support (e.g., `com.vanniktech.maven.publish` 0.28+), but that requires Gradle 8.1+ and Kotlin Gradle plugin ≥ 1.8 — out of scope here to avoid a major-version bump of the SDK's Kotlin baseline.