### PR TITLE
ci: Migrate Maven publishing to com.vanniktech.maven.publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,10 @@ jobs:
       - name: Publish
         env:
           MAVEN_SIGNING_KEY: ${{ secrets.MAVEN_SIGNING_KEY }}
-          NEXUS_SIGNING_PASSWORD: ${{ secrets.NEXUS_SIGNING_PASSWORD }}
-          MAVEN_USER_NAME: ${{ secrets.MAVEN_USER_NAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.NEXUS_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USER_NAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
 
         run: |
-          echo $MAVEN_SIGNING_KEY | base64 --decode > signing.key
-
-          cat << EOF > gradle.properties
-          signingPassword=${NEXUS_SIGNING_PASSWORD}
-          myNexusUsername=${MAVEN_USER_NAME}
-          myNexusPassword=${MAVEN_PASSWORD}
-          EOF
-
-          ./gradlew publishToMyNexus closeAndReleaseMyNexusStagingRepository -Prelease
+          ORG_GRADLE_PROJECT_signingInMemoryKey="$(echo "$MAVEN_SIGNING_KEY" | base64 --decode)" \
+            ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -Prelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,21 @@ jobs:
         run: |
           ./gradlew test --info
 
-      - name: Publish
+      - name: Decode signing key
         env:
           MAVEN_SIGNING_KEY: ${{ secrets.MAVEN_SIGNING_KEY }}
+        run: |
+          DECODED="$(echo "$MAVEN_SIGNING_KEY" | base64 --decode)"
+          echo "::add-mask::$DECODED"
+          {
+            echo "ORG_GRADLE_PROJECT_signingInMemoryKey<<__EOF__"
+            echo "$DECODED"
+            echo "__EOF__"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish
+        env:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.NEXUS_SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_USER_NAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_PASSWORD }}
-
-        run: |
-          ORG_GRADLE_PROJECT_signingInMemoryKey="$(echo "$MAVEN_SIGNING_KEY" | base64 --decode)" \
-            ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -Prelease
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -Prelease

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ if (!project.hasProperty("release")) {
 }
 
 plugins {
-  id("org.jetbrains.kotlin.jvm") version "2.1.21"
+  id("org.jetbrains.kotlin.jvm") version "2.3.21"
 
   id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 
@@ -17,13 +17,9 @@ plugins {
 
   id("org.jetbrains.dokka-javadoc") version "2.2.0"
 
-  id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
-
-  signing
+  id("com.vanniktech.maven.publish") version "0.36.0"
 
   `java-library`
-
-  `maven-publish`
 }
 
 repositories {
@@ -117,9 +113,6 @@ tasks.jar {
 java {
   sourceCompatibility = JavaVersion.VERSION_17
   targetCompatibility = JavaVersion.VERSION_17
-
-  withSourcesJar()
-  withJavadocJar()
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
@@ -132,65 +125,41 @@ tasks.withType<Test>().configureEach {
   useJUnitPlatform()
 }
 
-publishing {
-  publications {
-    create<MavenPublication>("maven") {
-      artifactId = "workos"
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  signAllPublications()
 
-      from(components["java"])
+  coordinates("com.workos", "workos", version.toString())
 
-      pom {
-        name.set("WorkOS SDK")
-        description.set(
-          "The WorkOS Kotlin library provides convenient access to the WorkOS API " +
-            "from applications written in JVM compatible languages."
-        )
-        url.set("https://github.com/workos-inc/workos-kotlin")
-        licenses {
-          license {
-            name.set("MIT License")
-            url.set("https://github.com/workos-inc/workos-kotlin/blob/main/LICENSE")
-          }
-        }
-        developers {
-          developer {
-            id.set("rframpton")
-            name.set("Robert Frampton")
-            email.set("rob@workos.com")
-          }
-          developer {
-            id.set("dliu-workos")
-            name.set("David Liu")
-            email.set("david.liu@workos.com")
-          }
-        }
-        scm {
-          connection.set("scm:git:git://github.com/workos-inc/workos-kotlin.git")
-          developerConnection.set("scm:git:git@github.com:workos-inc/workos-kotlin.git")
-          url.set("https://github.com/workos-inc/workos-kotlin")
-        }
+  pom {
+    name.set("WorkOS SDK")
+    description.set(
+      "The WorkOS Kotlin library provides convenient access to the WorkOS API " +
+        "from applications written in JVM compatible languages."
+    )
+    url.set("https://github.com/workos-inc/workos-kotlin")
+    licenses {
+      license {
+        name.set("MIT License")
+        url.set("https://github.com/workos-inc/workos-kotlin/blob/main/LICENSE")
       }
     }
-  }
-}
-
-nexusPublishing {
-  repositories {
-    create("myNexus") {
-      // Central Portal compatibility endpoints (post-OSSRH EOL June 30, 2025)
-      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+    developers {
+      developer {
+        id.set("rframpton")
+        name.set("Robert Frampton")
+        email.set("rob@workos.com")
+      }
+      developer {
+        id.set("dliu-workos")
+        name.set("David Liu")
+        email.set("david.liu@workos.com")
+      }
     }
-  }
-}
-
-signing {
-  val signingPassword: String? by project
-
-  if (signingPassword != null) {
-    val signingKey = File("signing.key").readText()
-
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications)
+    scm {
+      connection.set("scm:git:git://github.com/workos-inc/workos-kotlin.git")
+      developerConnection.set("scm:git:git@github.com:workos-inc/workos-kotlin.git")
+      url.set("https://github.com/workos-inc/workos-kotlin")
+    }
   }
 }


### PR DESCRIPTION
## Summary

Targets `next-major`. Replaces `gradle-nexus-publish-plugin` with **`com.vanniktech.maven.publish` 0.36.0**, which talks to the Sonatype Central Portal Publisher API directly instead of routing through the legacy OSSRH compatibility bridge. The bridge is what gave us [the "Failed to close staging repository … No objects found in the repository" failure](https://github.com/workos/workos-kotlin/actions/runs/25221973124/job/73956172228) on the 4.25.0 release; PR #373 is the in-place workaround for the 4.x line, and this PR is the durable fix going forward on `next-major`.

### Changes

- Replace plugin id `io.github.gradle-nexus.publish-plugin` with `com.vanniktech.maven.publish` 0.36.0.
- Drop the `maven-publish`, `signing` plugin ids and the standalone `publishing { ... }`, `nexusPublishing { ... }`, and `signing { ... }` blocks — Vanniktech wires all of those up itself.
- Drop `java { withSourcesJar(); withJavadocJar() }`; Vanniktech adds these. The Dokka-generated javadoc jar is picked up automatically because `org.jetbrains.dokka-javadoc` is on the plugin classpath.
- Add a single `mavenPublishing { ... }` block carrying coordinates, POM metadata, `publishToMavenCentral(automaticRelease = true)`, and `signAllPublications()`.
- Bump Kotlin Gradle plugin **2.1.21 → 2.3.21** to satisfy Vanniktech 0.36.0's Kotlin 2.2.0+ minimum.
- Update `.github/workflows/release.yml` to:
  - Run `./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -Prelease` (one task, no separate close/release).
  - Use Vanniktech's expected Gradle property names: `ORG_GRADLE_PROJECT_mavenCentralUsername`, `ORG_GRADLE_PROJECT_mavenCentralPassword`, `ORG_GRADLE_PROJECT_signingInMemoryKey`, `ORG_GRADLE_PROJECT_signingInMemoryKeyPassword`.
  - Decode the base64 GPG key inline into the env var rather than writing `signing.key` to disk.

### Secrets (no changes required)

Existing repo secrets are reused as-is — only the env var names they're injected under change:

| Secret | Used as |
|---|---|
| `MAVEN_USER_NAME` | `ORG_GRADLE_PROJECT_mavenCentralUsername` |
| `MAVEN_PASSWORD` | `ORG_GRADLE_PROJECT_mavenCentralPassword` |
| `MAVEN_SIGNING_KEY` (base64) | decoded into `ORG_GRADLE_PROJECT_signingInMemoryKey` |
| `NEXUS_SIGNING_PASSWORD` | `ORG_GRADLE_PROJECT_signingInMemoryKeyPassword` |

Note: Central Portal authenticates with **user tokens**, not Sonatype account login passwords. If `MAVEN_USER_NAME` / `MAVEN_PASSWORD` were ever set to the account login (rather than a token issued at https://central.sonatype.com/account), they'll need to be regenerated as a token before this works — but if 4.25.0 was authenticating via the bridge already, they're already tokens.

## Test plan

- [x] `./gradlew tasks --group=publishing` shows the expected Vanniktech tasks (`publishToMavenCentral`, `publishAndReleaseToMavenCentral`, etc.) — verified locally.
- [ ] Cut a `next-major` pre-release tag and confirm the `Release` workflow's `Publish to Maven` job completes and the artifact appears at https://central.sonatype.com.
- [ ] Verify the published POM still includes name, description, license, developers, and SCM blocks (no regressions vs. what we publish today).
- [ ] Verify the `-sources.jar` and Dokka-rendered `-javadoc.jar` are present on the artifact.

## Related

- PR #373 — in-place timing workaround for the same failure on the existing 4.x release pipeline. Kept open for the 4.25 release; this PR is the long-term replacement on `next-major`.