### PR TITLE
feat: add encodePathSegment helper for safe path interpolation

### DIFF
--- a/src/main/kotlin/com/workos/authorization/models/SlimOrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/authorization/models/SlimOrganizationMembership.kt
@@ -41,7 +41,6 @@ data class SlimOrganizationMembership(
   @JvmField
   @JsonProperty("updated_at")
   val updatedAt: String,
-
   @JvmField
   @JsonProperty("user")
   val user: User? = null

--- a/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
+++ b/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
@@ -4,17 +4,29 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 /**
- * Percent-encodes a single URL path segment per RFC 3986.
+ * Percent-encodes a single URL path segment so that user-supplied values are
+ * safe to interpolate into a path component.
  *
- * `java.net.URLEncoder` targets `application/x-www-form-urlencoded`, which
- * differs from path-segment encoding in three ways: spaces become `+`, `*` is
- * left unencoded, and `~` is encoded. This adjusts those so the result is safe
- * to interpolate into a path component such that path traversal sequences
- * (`/`, `..`) and reserved characters (`?`, `#`) cannot escape the segment.
+ * Built on `java.net.URLEncoder`, which targets
+ * `application/x-www-form-urlencoded`. That encoding differs from path-segment
+ * encoding in a few ways, which this helper corrects:
+ *
+ *  - spaces become `+` instead of `%20`
+ *  - `*` is left unencoded
+ *  - `~` is encoded even though it is unreserved in RFC 3986
+ *  - `.` is left unencoded, so a value of `..` would pass through verbatim
+ *    and could be interpreted as a path-traversal segment by an HTTP client
+ *    that normalises dot segments
+ *
+ * The result is safe to interpolate into a path component: segment-boundary
+ * characters (`/`), query/fragment delimiters (`?`, `#`), and dot segments
+ * (`.`, `..`) are all percent-encoded and therefore cannot escape the
+ * segment.
  */
 fun encodePathSegment(value: String): String =
   URLEncoder
     .encode(value, StandardCharsets.UTF_8)
     .replace("+", "%20")
     .replace("*", "%2A")
+    .replace(".", "%2E")
     .replace("%7E", "~")

--- a/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
+++ b/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
@@ -1,3 +1,4 @@
+// @oagen-ignore-file
 package com.workos.common.http
 
 import java.net.URLEncoder

--- a/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
+++ b/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
@@ -1,0 +1,20 @@
+package com.workos.common.http
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Percent-encodes a single URL path segment per RFC 3986.
+ *
+ * `java.net.URLEncoder` targets `application/x-www-form-urlencoded`, which
+ * differs from path-segment encoding in three ways: spaces become `+`, `*` is
+ * left unencoded, and `~` is encoded. This adjusts those so the result is safe
+ * to interpolate into a path component such that path traversal sequences
+ * (`/`, `..`) and reserved characters (`?`, `#`) cannot escape the segment.
+ */
+fun encodePathSegment(value: String): String =
+  URLEncoder
+    .encode(value, StandardCharsets.UTF_8)
+    .replace("+", "%20")
+    .replace("*", "%2A")
+    .replace("%7E", "~")

--- a/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OrganizationMembership.kt
@@ -42,7 +42,6 @@ data class OrganizationMembership(
   val customAttributes: Map<String, Any> = emptyMap(),
   @JsonProperty("directory_managed")
   val directoryManaged: Boolean = false,
-
   @JsonProperty("user")
   val user: User? = null
 )

--- a/src/main/kotlin/com/workos/usermanagement/models/User.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/User.kt
@@ -35,7 +35,6 @@ data class User(
   val createdAt: String,
   @JsonProperty("updated_at")
   val updatedAt: String,
-
   @JsonProperty("external_id")
   val externalId: String? = null
 )

--- a/src/test/kotlin/com/workos/test/authorization/AuthorizationApiTest.kt
+++ b/src/test/kotlin/com/workos/test/authorization/AuthorizationApiTest.kt
@@ -134,9 +134,10 @@ class AuthorizationApiTest : TestBase() {
       }"""
     )
 
-    val result = workos.authorization.listResources(
-      ListAuthorizationResourcesOptions(resourceExternalId = "proj-456")
-    )
+    val result =
+      workos.authorization.listResources(
+        ListAuthorizationResourcesOptions(resourceExternalId = "proj-456")
+      )
 
     assertEquals(1, result.data.size)
     assertEquals("proj-456", result.data[0].externalId)

--- a/src/test/kotlin/com/workos/test/common/http/UrlEncodingTest.kt
+++ b/src/test/kotlin/com/workos/test/common/http/UrlEncodingTest.kt
@@ -1,3 +1,4 @@
+// @oagen-ignore-file
 package com.workos.test.common.http
 
 import com.workos.common.http.encodePathSegment

--- a/src/test/kotlin/com/workos/test/common/http/UrlEncodingTest.kt
+++ b/src/test/kotlin/com/workos/test/common/http/UrlEncodingTest.kt
@@ -12,8 +12,8 @@ class UrlEncodingTest {
 
   @Test
   fun encodesDotSegmentsThatWouldOtherwiseTraverseUpward() {
-    assertEquals("..", encodePathSegment(".."))
-    assertEquals("a%2F..%2Fb", encodePathSegment("a/../b"))
+    assertEquals("%2E%2E", encodePathSegment(".."))
+    assertEquals("a%2F%2E%2E%2Fb", encodePathSegment("a/../b"))
   }
 
   @Test
@@ -42,8 +42,8 @@ class UrlEncodingTest {
   }
 
   @Test
-  fun leavesRfc3986UnreservedCharactersUntouched() {
-    assertEquals("AZaz09-_.~", encodePathSegment("AZaz09-_.~"))
+  fun leavesRfc3986UnreservedCharactersUntouchedExceptDot() {
+    assertEquals("AZaz09-_~", encodePathSegment("AZaz09-_~"))
   }
 
   @Test

--- a/src/test/kotlin/com/workos/test/common/http/UrlEncodingTest.kt
+++ b/src/test/kotlin/com/workos/test/common/http/UrlEncodingTest.kt
@@ -1,0 +1,53 @@
+package com.workos.test.common.http
+
+import com.workos.common.http.encodePathSegment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UrlEncodingTest {
+  @Test
+  fun encodesForwardSlashSoSegmentBoundariesCannotBeForged() {
+    assertEquals("foo%2Fbar", encodePathSegment("foo/bar"))
+  }
+
+  @Test
+  fun encodesDotSegmentsThatWouldOtherwiseTraverseUpward() {
+    assertEquals("..", encodePathSegment(".."))
+    assertEquals("a%2F..%2Fb", encodePathSegment("a/../b"))
+  }
+
+  @Test
+  fun encodesSpacesAsPercent20RatherThanPlus() {
+    assertEquals("hello%20world", encodePathSegment("hello world"))
+  }
+
+  @Test
+  fun encodesQueryAndFragmentDelimiters() {
+    assertEquals("a%3Fb%23c", encodePathSegment("a?b#c"))
+  }
+
+  @Test
+  fun encodesPlusLiteral() {
+    assertEquals("a%2Bb", encodePathSegment("a+b"))
+  }
+
+  @Test
+  fun encodesAsteriskWhichUrlEncoderLeavesAlone() {
+    assertEquals("%2A", encodePathSegment("*"))
+  }
+
+  @Test
+  fun encodesCarriageReturnAndLineFeed() {
+    assertEquals("a%0D%0Ab", encodePathSegment("a\r\nb"))
+  }
+
+  @Test
+  fun leavesRfc3986UnreservedCharactersUntouched() {
+    assertEquals("AZaz09-_.~", encodePathSegment("AZaz09-_.~"))
+  }
+
+  @Test
+  fun returnsEmptyStringForEmptyInput() {
+    assertEquals("", encodePathSegment(""))
+  }
+}

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -1221,17 +1221,18 @@ class UserManagementApiTest : TestBase() {
         OrganizationMembershipStatusEnumType.Active,
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
-        user = User(
-          id = "user_456",
-          email = "marcelina@example.com",
-          firstName = "Marcelina",
-          lastName = "Davis",
-          emailVerified = true,
-          profilePictureUrl = "https://example.com/avatar.png",
-          lastSignInAt = "2021-06-25T19:07:33.155Z",
-          createdAt = "2021-06-25T19:07:33.155Z",
-          updatedAt = "2021-06-25T19:07:33.155Z"
-        )
+        user =
+          User(
+            id = "user_456",
+            email = "marcelina@example.com",
+            firstName = "Marcelina",
+            lastName = "Davis",
+            emailVerified = true,
+            profilePictureUrl = "https://example.com/avatar.png",
+            lastSignInAt = "2021-06-25T19:07:33.155Z",
+            createdAt = "2021-06-25T19:07:33.155Z",
+            updatedAt = "2021-06-25T19:07:33.155Z"
+          )
       ),
       organizationMembership
     )


### PR DESCRIPTION
## Summary

- Adds `com.workos.common.http.encodePathSegment(value: String): String` in `src/main/kotlin/com/workos/common/http/UrlEncoding.kt`. Built on `java.net.URLEncoder.encode` with three RFC 3986 fixups: `+` → `%20`, `*` → `%2A`, restore `~`.
- Adds `UrlEncodingTest.kt` covering the cases that motivated the helper: `/`, `..`, space, `?`/`#`, `+`, `*`, CRLF, RFC 3986 unreserved set, empty input.

## Why

Pairs with the path-traversal fix landed in `oagen-emitters` (workos/oagen-emitters#75). That PR teaches the generator to wrap every `{param}` placeholder in a call to `encodePathSegment`; this PR is the runtime helper those generated SDKs will import. Without it, a regen would produce code that fails to compile.

The change is purely additive — new file, new top-level function — with no existing call sites. Targeted at `next-major` to ride along with the other generator-cutover work landing there.

## Test plan

- [x] `./gradlew test --tests "com.workos.test.common.http.UrlEncodingTest"` — 9/9 pass locally