### PR TITLE
feat: publish Dokka API docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Publish API Docs
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - run: ./script/docs
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs/_site
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,21 @@ jobs:
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - run: ./script/docs
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+      - name: Archive site
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory docs/_site \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: docs/_site
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
   deploy:
     needs: build
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ bin
 # Credentials
 gradle.properties
 signing.key
+
+# Generated API docs site
+docs/_site/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,8 +121,10 @@ abstract class DokkaMarkdownPlugin : DokkaFormatPlugin(formatName = "markdown") 
   override fun DokkaFormatPlugin.DokkaFormatPluginContext.configure() {
     project.dependencies {
       dokkaPlugin(dokka("gfm-plugin"))
-      formatDependencies.dokkaPublicationPluginClasspathApiOnly
-        .dependencies.addLater(dokka("gfm-template-processing-plugin"))
+      formatDependencies
+        .dokkaPublicationPluginClasspathApiOnly
+        .dependencies
+        .addLater(dokka("gfm-template-processing-plugin"))
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
-import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.dokka.gradle.formats.DokkaFormatPlugin
+import org.jetbrains.dokka.gradle.internal.InternalDokkaGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import java.util.Properties
@@ -99,6 +100,9 @@ tasks.named("javadoc") {
 dokka {
   dokkaPublications.javadoc {
     outputDirectory.set(layout.buildDirectory.dir("docs/javadoc"))
+  }
+
+  dokkaPublications.configureEach {
     failOnWarning.set(true)
   }
 
@@ -107,9 +111,23 @@ dokka {
   }
 }
 
-tasks.withType<DokkaTask>().configureEach {
-  failOnWarning.set(true)
+// GFM (GitHub-Flavored Markdown) output via the official DokkaFormatPlugin
+// extension point. DGP v2 doesn't ship a built-in markdown format, but the
+// gfm-plugin artifacts are still published, and JetBrains documents this
+// pattern as the supported way to wire them in. Produces a `dokkaGenerateMarkdown`
+// task whose output lands in build/dokka/markdown/.
+@OptIn(InternalDokkaGradlePluginApi::class)
+abstract class DokkaMarkdownPlugin : DokkaFormatPlugin(formatName = "markdown") {
+  override fun DokkaFormatPlugin.DokkaFormatPluginContext.configure() {
+    project.dependencies {
+      dokkaPlugin(dokka("gfm-plugin"))
+      formatDependencies.dokkaPublicationPluginClasspathApiOnly
+        .dependencies.addLater(dokka("gfm-template-processing-plugin"))
+    }
+  }
 }
+
+apply<DokkaMarkdownPlugin>()
 
 tasks.jar {
   manifest {

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+
+rm -rf docs/_site
+mkdir -p docs/_site
+
+./gradlew dokkaGenerateHtml dokkaGenerateMarkdown -Prelease
+
+cp -R build/dokka/html/. docs/_site/
+cp -R build/dokka/markdown/. docs/_site/

--- a/script/docs
+++ b/script/docs
@@ -9,3 +9,18 @@ mkdir -p docs/_site
 
 cp -R build/dokka/html/. docs/_site/
 cp -R build/dokka/markdown/. docs/_site/
+
+# llms.txt — index of the Markdown mirror for LLM/agent consumption.
+# Every .html page has a sibling .md at the same path.
+SITE="https://workos.github.io/workos-kotlin"
+{
+  printf '# WorkOS Kotlin SDK\n\n'
+  printf '> Markdown mirror of the WorkOS Kotlin SDK API reference for LLM and agent consumption. Every HTML page on this site has a sibling Markdown file at the same path with a `.md` suffix.\n\n'
+  printf '## Packages\n\n'
+  (cd docs/_site && find . -mindepth 2 -maxdepth 2 -name 'index.md' | sort) \
+    | while IFS= read -r f; do
+        rel="${f#./}"
+        pkg="${rel%/index.md}"
+        printf -- '- [%s](%s/%s)\n' "$pkg" "$SITE" "$rel"
+      done
+} > docs/_site/llms.txt

--- a/script/docs-serve
+++ b/script/docs-serve
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+
+if [ ! -d docs/_site ]; then
+  ./script/docs
+fi
+
+exec python3 -m http.server 4000 --directory docs/_site


### PR DESCRIPTION
## Summary
- Add a `docs.yml` workflow that builds Dokka HTML + GFM output and deploys it to GitHub Pages on tag pushes
- Configure Dokka in `build.gradle.kts` to title the published docs without the `-SNAPSHOT` suffix when built with `-Prelease`
- Add `script/docs` and `script/docs-serve` helpers for building and previewing docs locally
- Update `.gitignore` to exclude generated docs output

## Test plan
- [ ] CI: `docs.yml` runs successfully on this PR (build job)
- [ ] Run `script/docs` locally and verify HTML + GFM output is generated under the expected path
- [ ] Run `script/docs-serve` locally and confirm the docs render in a browser
- [ ] Verify the published title omits `-SNAPSHOT` when built with `-Prelease`
- [ ] After merge + tag push, confirm Pages deployment succeeds and the site is reachable