### PR TITLE
fix: harden URL/token handling and webhook timestamp validation

### DIFF
--- a/src/main/kotlin/com/workos/common/http/BaseClient.kt
+++ b/src/main/kotlin/com/workos/common/http/BaseClient.kt
@@ -319,12 +319,44 @@ open class BaseClient(
     return when (status) {
       400 -> BadRequestException(requestId, code, message, errors, body)
       401 -> UnauthorizedException(requestId, code, message, body)
-      404 -> NotFoundException(requestId, code, message, url, body)
+      404 -> NotFoundException(requestId, code, message, redactSensitivePath(url), body)
       422 -> UnprocessableEntityException(requestId, code, message, errors, body)
       429 -> RateLimitException(requestId, code, message, retryAfterHeader?.let { RetryPolicy.parseRetryAfter(it)?.div(1000L) }, body)
       in 500..599 -> GenericServerException(status, requestId, code, message, body)
       else -> WorkOSGenericException(status, requestId, code, message, body)
     }
+  }
+
+  /**
+   * Redact bearer-equivalent path segments before they get embedded in
+   * exception messages or downstream logs (security finding #51, mirrors
+   * the Ruby `base_client.rb` redaction list from #44).
+   *
+   * The WorkOS API exposes several endpoints whose path segment IS the
+   * secret — invitation tokens (`/user_management/invitations/by_token/{token}`),
+   * password-reset / email-verification / magic-auth single-use tokens.
+   * Anyone with read access to a 404's exception trail would otherwise be
+   * able to replay the token. We replace the secret segment with
+   * `[REDACTED]` while keeping the route prefix intact for debuggability.
+   */
+  private fun redactSensitivePath(url: String): String {
+    var redacted = url
+    for (pattern in SENSITIVE_PATH_PATTERNS) {
+      redacted = pattern.replace(redacted, "$1[REDACTED]")
+    }
+    return redacted
+  }
+
+  private companion object {
+    private val SENSITIVE_PATH_PATTERNS: List<Regex> =
+      listOf(
+        Regex("(/user_management/invitations/by_token/)[^/?#]+"),
+        // Exclude the literal `confirm` action so we only redact the
+        // single-use secret IDs.
+        Regex("(/user_management/password_reset/)(?!confirm(?:[/?#]|$))[^/?#]+"),
+        Regex("(/user_management/email_verification/)[^/?#]+"),
+        Regex("(/user_management/magic_auth/)[^/?#]+")
+      )
   }
 
   private fun parseApiError(body: String): Triple<String?, String?, List<ApiError>?> {

--- a/src/main/kotlin/com/workos/common/http/RequestHelpers.kt
+++ b/src/main/kotlin/com/workos/common/http/RequestHelpers.kt
@@ -1,19 +1,6 @@
 // @oagen-ignore-file
 package com.workos.common.http
 
-import java.net.URLEncoder
-
-/**
- * Percent-encode a value for safe interpolation into a URL path segment.
- *
- * Generated resource methods inline path parameters via Kotlin string
- * templates (e.g. `"/orgs/${encodePathSegment(id)}"`); without encoding, an
- * id containing `/`, `?`, `#`, or whitespace would alter routing or break
- * the request. `URLEncoder` targets form-encoding so ` ` becomes `+`; the
- * post-replace converts those back to `%20` for path-segment correctness.
- */
-fun encodePathSegment(value: String): String = URLEncoder.encode(value, Charsets.UTF_8).replace("+", "%20")
-
 /**
  * Build a request body map from key-value pairs, dropping entries whose
  * value is `null`. This reduces the repeated `if (x != null) body["x"] = x`

--- a/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
+++ b/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
@@ -1,0 +1,62 @@
+// @oagen-ignore-file
+// RFC 3986 path-segment percent-encoding helper used by every generated
+// service to encode interpolated path parameters (e.g. `${encodePathSegment(id)}`).
+//
+// `URLEncoder.encode` performs `application/x-www-form-urlencoded` encoding,
+// which is wrong for path segments in three ways that matter here:
+//   - it encodes space as `+` (path segments require `%20`)
+//   - it does not encode `+` (which has no special meaning in a path but
+//     is decoded back to space on the other side, mangling the value)
+//   - it percent-encodes `~` (which is RFC 3986 unreserved and must NOT be
+//     encoded), and likewise does not consistently leave `*` alone.
+//
+// We start from the form encoder's output and post-process to align with
+// RFC 3986 Section 3.3 path-segment rules. Crucially, `/` is encoded as
+// `%2F` so a malicious id like `..%2Fadmin` cannot escape its segment.
+package com.workos.common.http
+
+import java.net.URLEncoder
+
+/**
+ * Percent-encode [value] for safe interpolation as a single URI path segment
+ * per RFC 3986 §3.3. All reserved characters (`/`, `?`, `#`, etc.) and
+ * sub-delims that could change parsing are encoded; `~` and other unreserved
+ * characters are left alone.
+ */
+fun encodePathSegment(value: String): String {
+  val formEncoded = URLEncoder.encode(value, Charsets.UTF_8)
+  val out = StringBuilder(formEncoded.length)
+  var i = 0
+  while (i < formEncoded.length) {
+    val c = formEncoded[i]
+    when {
+      // form encoder emits '+' for space; path segments use %20
+      c == '+' -> {
+        out.append("%20")
+        i += 1
+      }
+      // form encoder leaves '*' unescaped; it's a sub-delim, encode it for safety
+      c == '*' -> {
+        out.append("%2A")
+        i += 1
+      }
+      c == '%' && i + 2 < formEncoded.length -> {
+        val hex = formEncoded.substring(i + 1, i + 3).uppercase()
+        when (hex) {
+          // '~' is unreserved — must not be percent-encoded
+          "7E" -> out.append('~')
+          else -> {
+            out.append('%')
+            out.append(hex)
+          }
+        }
+        i += 3
+      }
+      else -> {
+        out.append(c)
+        i += 1
+      }
+    }
+  }
+  return out.toString()
+}

--- a/src/main/kotlin/com/workos/webhooks/Webhook.kt
+++ b/src/main/kotlin/com/workos/webhooks/Webhook.kt
@@ -98,8 +98,7 @@ class Webhook
       val (timestamp, signatureHash) = parseSignatureHeader(signatureHeader, setOf("v1", "s"))
 
       val timestampMs = timestamp.toLongOrNull() ?: throw SignatureException("Timestamp is not a valid long value")
-      val oldestAcceptable = Instant.now().toEpochMilli() - toleranceMillis
-      if (timestampMs < oldestAcceptable) {
+      if (kotlin.math.abs(Instant.now().toEpochMilli() - timestampMs) > toleranceMillis) {
         throw SignatureException("Timestamp outside the tolerance zone")
       }
 

--- a/src/test/kotlin/com/workos/common/http/BaseClientErrorMappingTest.kt
+++ b/src/test/kotlin/com/workos/common/http/BaseClientErrorMappingTest.kt
@@ -93,6 +93,109 @@ class BaseClientErrorMappingTest : TestBase() {
     assertEquals("Not here", ex.message)
   }
 
+  /**
+   * Regression test for finding #51: bearer-equivalent path tokens are
+   * redacted out of `NotFoundException.path` before the exception is
+   * constructed. The token segment must be replaced with `[REDACTED]` so
+   * that anyone capturing the exception (logs, error reporting) cannot
+   * recover the secret. Mirrors the Ruby #44 redaction list.
+   */
+  private fun assert404RedactsPath(
+    path: String,
+    redactedPath: String
+  ) {
+    wireMockRule.stubFor(
+      get(urlPathEqualTo(path))
+        .willReturn(
+          aResponse()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json")
+            .withHeader("X-Request-Id", "req_01TEST")
+            .withBody("""{"message": "not found"}""")
+        )
+    )
+    val client = createWorkOSClient()
+    val ex =
+      assertThrows(NotFoundException::class.java) {
+        client.baseClient.request(
+          RequestConfig(method = "GET", path = path, queryParams = emptyList()),
+          Map::class.java
+        )
+      }
+    val storedPath = ex.path
+    assertNotNull(storedPath)
+    assertTrue(
+      storedPath!!.endsWith(redactedPath),
+      "expected path to end with $redactedPath but was $storedPath"
+    )
+    // Cross-check the original token never appears in the stored path.
+    val tokenSegment = path.substringAfterLast('/')
+    assertTrue(
+      !storedPath.contains(tokenSegment),
+      "exception path leaked sensitive segment $tokenSegment: $storedPath"
+    )
+  }
+
+  @Test
+  fun `404 redacts invitation by_token`() {
+    assert404RedactsPath(
+      path = "/user_management/invitations/by_token/super-secret-token-123",
+      redactedPath = "/user_management/invitations/by_token/[REDACTED]"
+    )
+  }
+
+  @Test
+  fun `404 redacts password reset token`() {
+    assert404RedactsPath(
+      path = "/user_management/password_reset/super-secret-reset-456",
+      redactedPath = "/user_management/password_reset/[REDACTED]"
+    )
+  }
+
+  @Test
+  fun `404 redacts email verification token`() {
+    assert404RedactsPath(
+      path = "/user_management/email_verification/super-secret-verify-789",
+      redactedPath = "/user_management/email_verification/[REDACTED]"
+    )
+  }
+
+  @Test
+  fun `404 redacts magic auth token`() {
+    assert404RedactsPath(
+      path = "/user_management/magic_auth/super-secret-magic-000",
+      redactedPath = "/user_management/magic_auth/[REDACTED]"
+    )
+  }
+
+  @Test
+  fun `404 leaves password reset confirm action unredacted`() {
+    // /password_reset/confirm is a literal action endpoint, not a token.
+    wireMockRule.stubFor(
+      get(urlPathEqualTo("/user_management/password_reset/confirm"))
+        .willReturn(
+          aResponse()
+            .withStatus(404)
+            .withHeader("Content-Type", "application/json")
+            .withHeader("X-Request-Id", "req_01TEST")
+            .withBody("""{"message": "not found"}""")
+        )
+    )
+    val client = createWorkOSClient()
+    val ex =
+      assertThrows(NotFoundException::class.java) {
+        client.baseClient.request(
+          RequestConfig(
+            method = "GET",
+            path = "/user_management/password_reset/confirm",
+            queryParams = emptyList()
+          ),
+          Map::class.java
+        )
+      }
+    assertTrue(ex.path!!.endsWith("/user_management/password_reset/confirm"))
+  }
+
   @Test
   fun `409 falls through to WorkOSGenericException with 409 status`() {
     val ex = runErrorCase<WorkOSGenericException>(409, """{"message": "Conflict"}""")

--- a/src/test/kotlin/com/workos/common/http/EncodePathSegmentTest.kt
+++ b/src/test/kotlin/com/workos/common/http/EncodePathSegmentTest.kt
@@ -28,4 +28,40 @@ class EncodePathSegmentTest {
   fun `encodes non-ASCII as UTF-8 percent escapes`() {
     assertEquals("caf%C3%A9", encodePathSegment("café"))
   }
+
+  @Test
+  fun `does not percent-encode tilde`() {
+    // RFC 3986 marks `~` as unreserved; URLEncoder's form encoding wrongly
+    // emits `%7E`, and we must decode it back so the segment is canonical.
+    assertEquals("a~b", encodePathSegment("a~b"))
+    assertEquals("~", encodePathSegment("~"))
+  }
+
+  @Test
+  fun `prevents path traversal by encoding slashes`() {
+    // A literal `..` is not by itself dangerous (the server resolves it as a
+    // segment), but any embedded `/` must be encoded so a malicious id
+    // cannot escape its own segment.
+    assertEquals("..", encodePathSegment(".."))
+    assertEquals("..%2Fadmin", encodePathSegment("../admin"))
+    assertEquals("foo%2F..%2Fbar", encodePathSegment("foo/../bar"))
+  }
+
+  @Test
+  fun `encodes wider unicode (multi-byte) correctly`() {
+    // Emoji forces a 4-byte UTF-8 sequence to exercise the percent loop.
+    assertEquals("%F0%9F%94%92", encodePathSegment("🔒"))
+  }
+
+  @Test
+  fun `encodes plus sign so it round-trips as plus, not space`() {
+    // URLEncoder leaves `+` alone; without post-processing the server would
+    // decode it back to a space.
+    assertEquals("a%2Bb", encodePathSegment("a+b"))
+  }
+
+  @Test
+  fun `encodes asterisk for safety`() {
+    assertEquals("a%2Ab", encodePathSegment("a*b"))
+  }
 }

--- a/src/test/kotlin/com/workos/webhooks/WebhookVerifierTest.kt
+++ b/src/test/kotlin/com/workos/webhooks/WebhookVerifierTest.kt
@@ -54,6 +54,47 @@ class WebhookVerifierTest {
     }
   }
 
+  /**
+   * Regression test for security finding #48 (HMAC leak via exception message).
+   *
+   * The signature mismatch path must never include the expected HMAC in the
+   * thrown exception message: that would let an attacker who can observe
+   * exception text recover the signing secret's MAC for a payload they
+   * control. The current implementation throws a constant
+   * "Signatures do not match" string, but we assert here that no SHA-256
+   * hex string (length 64) can be found anywhere in the exception message
+   * so the regression is mechanically caught if the message ever changes.
+   */
+  @Test
+  fun `mismatched signature exception leaks no HMAC hex`() {
+    val timestamp = Instant.now().toEpochMilli().toString()
+    val tamperedPayload = """{"tampered":true}"""
+    val signature = webhooks.createSignature(timestamp, payload, secret)
+    val header = "t=$timestamp, v1=$signature"
+
+    val ex =
+      assertThrows(SignatureException::class.java) {
+        webhooks.verifyHeader(tamperedPayload, header, secret, 60_000)
+      }
+
+    val message = ex.message.orEmpty()
+    val hex64 = Regex("[0-9a-fA-F]{64}")
+    assertTrue(
+      !hex64.containsMatchIn(message),
+      "Exception message must not contain a 64-char hex string (HMAC leak): $message"
+    )
+    // Defense in depth: the actual HMAC for this payload must not appear.
+    val expectedHmac = webhooks.createSignature(timestamp, tamperedPayload, secret)
+    assertTrue(
+      !message.contains(expectedHmac),
+      "Exception message must not contain the computed HMAC: $message"
+    )
+    assertTrue(
+      !message.contains(signature),
+      "Exception message must not contain the provided HMAC: $message"
+    )
+  }
+
   @Test
   fun `malformed header is rejected`() {
     assertThrows(SignatureException::class.java) {

--- a/src/test/kotlin/com/workos/webhooks/WebhookVerifierTest.kt
+++ b/src/test/kotlin/com/workos/webhooks/WebhookVerifierTest.kt
@@ -46,6 +46,16 @@ class WebhookVerifierTest {
   }
 
   @Test
+  fun `future timestamp beyond tolerance is rejected`() {
+    val futureTs = (Instant.now().toEpochMilli() + 10 * 60_000).toString()
+    val signature = webhooks.createSignature(futureTs, payload, secret)
+    val header = "t=$futureTs, v1=$signature"
+    assertThrows(SignatureException::class.java) {
+      webhooks.verifyHeader(payload, header, secret, 60_000)
+    }
+  }
+
+  @Test
   fun `mismatched signature is rejected`() {
     val timestamp = Instant.now().toEpochMilli().toString()
     val header = "t=$timestamp, v1=0000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- Redact single-use secrets (invitation, password-reset, email-verification, magic-auth tokens) from `NotFoundException.path` in `BaseClient.translateHttpFailure` so 404s no longer surface replayable tokens to exception loggers. The `password_reset/confirm` literal action segment is intentionally exempt.
- Make webhook timestamp tolerance symmetric (`abs(now - timestampMs) > toleranceMillis`) so clock-skewed or attacker-minted future timestamps can no longer be replayed indefinitely.
- Add `com.workos.common.http.encodePathSegment` (RFC 3986 §3.3): wraps `URLEncoder.encode`, swaps `+`→`%20`, decodes `%7E`→`~`, encodes `*`→`%2A`. Replaces the weaker helper in `RequestHelpers.kt` (no compat shim — generated services already call the new path).
- Lock in webhook HMAC-leak protection with a regression test asserting no 64-char hex appears in the `SignatureException` message thrown from `Webhook.kt`.

## Test plan
- [ ] `./gradlew test` passes locally
- [ ] `BaseClientErrorMappingTest` verifies redaction for each token-bearing path and that the `password_reset/confirm` route is untouched
- [ ] `EncodePathSegmentTest` covers `/`, `..`, `?`, `#`, space, multi-byte unicode, `~`, `+`, `*`
- [ ] `WebhookVerifierTest` covers symmetric tolerance (past + future) and the HMAC-leak regression
- [ ] Spot-check a generated service file still resolves `encodePathSegment` from `com.workos.common.http`